### PR TITLE
Dynamic datalake generator first version added

### DIFF
--- a/node-red/flows_js/change.080d51ddc857aa0f.flows.js
+++ b/node-red/flows_js/change.080d51ddc857aa0f.flows.js
@@ -21,9 +21,11 @@ const Node = {
   "x": 1150,
   "y": 200,
   "wires": [
-    []
+    [
+      "cd2e6087b8df1d90"
+    ]
   ],
-  "_order": 265
+  "_order": 326
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.0ef69341b2942667.flows.js
+++ b/node-red/flows_js/change.0ef69341b2942667.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "080d51ddc857aa0f"
     ]
   ],
-  "_order": 264
+  "_order": 325
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.0f9cc8245b0bfdac.flows.js
+++ b/node-red/flows_js/change.0f9cc8245b0bfdac.flows.js
@@ -1,0 +1,31 @@
+const Node = {
+  "id": "0f9cc8245b0bfdac",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Create status object",
+  "rules": [
+    {
+      "t": "set",
+      "p": "status",
+      "pt": "msg",
+      "to": "{\t   \"fill\": \"yellow\",\t   \"shape\":\"ring\",\t   \"text\": statusCode & \" \" & payload.error.message\t}",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 1180,
+  "y": 60,
+  "wires": [
+    [
+      "1cbaf9dd5f00f15d"
+    ]
+  ],
+  "_order": 227
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.1817ef0c011528f5.flows.js
+++ b/node-red/flows_js/change.1817ef0c011528f5.flows.js
@@ -47,7 +47,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 114
+  "_order": 133
 }
 
 Node.info = `

--- a/node-red/flows_js/change.1ae4294ce24de36c.flows.js
+++ b/node-red/flows_js/change.1ae4294ce24de36c.flows.js
@@ -40,7 +40,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 240
+  "_order": 301
 }
 
 Node.info = `

--- a/node-red/flows_js/change.24fba0b7beae16a9.flows.js
+++ b/node-red/flows_js/change.24fba0b7beae16a9.flows.js
@@ -47,7 +47,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 160
+  "_order": 179
 }
 
 Node.info = `

--- a/node-red/flows_js/change.3213d6b6dcbc1775.flows.js
+++ b/node-red/flows_js/change.3213d6b6dcbc1775.flows.js
@@ -29,7 +29,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 127
+  "_order": 146
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.3302debcb6e0a7d8.flows.js
+++ b/node-red/flows_js/change.3302debcb6e0a7d8.flows.js
@@ -39,7 +39,7 @@ const Node = {
       "2572a9725c8bd282"
     ]
   ],
-  "_order": 178
+  "_order": 239
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.376236699fa4f2cc.flows.js
+++ b/node-red/flows_js/change.376236699fa4f2cc.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "351286a4aae46341"
     ]
   ],
-  "_order": 164
+  "_order": 183
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.38291a57af9afb3e.flows.js
+++ b/node-red/flows_js/change.38291a57af9afb3e.flows.js
@@ -1,0 +1,31 @@
+const Node = {
+  "id": "38291a57af9afb3e",
+  "type": "change",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "Rens komma fra kolonner",
+  "rules": [
+    {
+      "t": "set",
+      "p": "columns",
+      "pt": "msg",
+      "to": "$substring(columns, 0, $length(columns) - 2)",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 850,
+  "y": 400,
+  "wires": [
+    [
+      "4587d61d62e5e743"
+    ]
+  ],
+  "_order": 333
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.3d995f447af30ece.flows.js
+++ b/node-red/flows_js/change.3d995f447af30ece.flows.js
@@ -24,7 +24,7 @@ const Node = {
       "3fcc4bd01ebeb3cf"
     ]
   ],
-  "_order": 129
+  "_order": 148
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.4570c6c9a34474fa.flows.js
+++ b/node-red/flows_js/change.4570c6c9a34474fa.flows.js
@@ -28,7 +28,7 @@ const Node = {
       "bef728771c500c07"
     ]
   ],
-  "_order": 176
+  "_order": 237
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.4587d61d62e5e743.flows.js
+++ b/node-red/flows_js/change.4587d61d62e5e743.flows.js
@@ -1,0 +1,43 @@
+const Node = {
+  "id": "4587d61d62e5e743",
+  "type": "change",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "Rename and set tablename \\n from dataset name",
+  "rules": [
+    {
+      "t": "set",
+      "p": "dataset",
+      "pt": "msg",
+      "to": "$replace(dataset, \"-\", \"_\") /* To use the tablename in mysql/mariadb only underscores are allowed as special characters */ ",
+      "tot": "jsonata"
+    },
+    {
+      "t": "set",
+      "p": "tablename",
+      "pt": "flow",
+      "to": "\"opendata\" & \"_\" & dataset",
+      "tot": "jsonata"
+    },
+    {
+      "t": "delete",
+      "p": "payload",
+      "pt": "msg"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 240,
+  "y": 500,
+  "wires": [
+    [
+      "cc4372cb27df1b3d"
+    ]
+  ],
+  "_order": 338
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.46868fe38cf5a184.flows.js
+++ b/node-red/flows_js/change.46868fe38cf5a184.flows.js
@@ -39,7 +39,7 @@ const Node = {
       "a23d55dbf287fcfa"
     ]
   ],
-  "_order": 201
+  "_order": 262
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.485a43a04e99f6b3.flows.js
+++ b/node-red/flows_js/change.485a43a04e99f6b3.flows.js
@@ -28,7 +28,7 @@ const Node = {
       "5476474f50f31f4e"
     ]
   ],
-  "_order": 198
+  "_order": 259
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.487ad510ea1fe3e0.flows.js
+++ b/node-red/flows_js/change.487ad510ea1fe3e0.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "487ad510ea1fe3e0",
+  "type": "change",
+  "z": "80076417ef9f662a",
+  "name": "Get timestamp",
+  "rules": [
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "$millis()",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 860,
+  "y": 80,
+  "wires": [
+    [
+      "912cd2c68d0d95f1"
+    ]
+  ],
+  "_order": 192
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.4e0b98bc09a1a4b7.flows.js
+++ b/node-red/flows_js/change.4e0b98bc09a1a4b7.flows.js
@@ -46,7 +46,7 @@ const Node = {
       "1817ef0c011528f5"
     ]
   ],
-  "_order": 113
+  "_order": 132
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.5476474f50f31f4e.flows.js
+++ b/node-red/flows_js/change.5476474f50f31f4e.flows.js
@@ -39,7 +39,7 @@ const Node = {
       "8ad4b29a3e40eee8"
     ]
   ],
-  "_order": 199
+  "_order": 260
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.54ac54f14b340491.flows.js
+++ b/node-red/flows_js/change.54ac54f14b340491.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "a1043807c29f2e48"
     ]
   ],
-  "_order": 126
+  "_order": 145
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.54bea232f93f8f0b.flows.js
+++ b/node-red/flows_js/change.54bea232f93f8f0b.flows.js
@@ -43,7 +43,7 @@ const Node = {
       "3f641fcece5a6ba2"
     ]
   ],
-  "_order": 173
+  "_order": 234
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.5da16564b7f0f0c1.flows.js
+++ b/node-red/flows_js/change.5da16564b7f0f0c1.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "b7fbaea9143be3f1"
     ]
   ],
-  "_order": 103
+  "_order": 122
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.627b9982c16502f9.flows.js
+++ b/node-red/flows_js/change.627b9982c16502f9.flows.js
@@ -26,7 +26,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 239
+  "_order": 300
 }
 
 Node.info = `

--- a/node-red/flows_js/change.65e7437a46c33c4d.flows.js
+++ b/node-red/flows_js/change.65e7437a46c33c4d.flows.js
@@ -40,7 +40,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 215
+  "_order": 276
 }
 
 Node.info = `

--- a/node-red/flows_js/change.66b59f8b5f624673.flows.js
+++ b/node-red/flows_js/change.66b59f8b5f624673.flows.js
@@ -1,0 +1,31 @@
+const Node = {
+  "id": "66b59f8b5f624673",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "data",
+  "rules": [
+    {
+      "t": "move",
+      "p": "payload",
+      "pt": "msg",
+      "to": "data",
+      "tot": "msg"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 970,
+  "y": 420,
+  "wires": [
+    [
+      "a87301fa2a0d3ad8"
+    ]
+  ],
+  "_order": 218
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.6c7c743d5b7e2aab.flows.js
+++ b/node-red/flows_js/change.6c7c743d5b7e2aab.flows.js
@@ -24,7 +24,7 @@ const Node = {
       "3fcc4bd01ebeb3cf"
     ]
   ],
-  "_order": 130
+  "_order": 149
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.6ce841fbce39163d.flows.js
+++ b/node-red/flows_js/change.6ce841fbce39163d.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "1582f6ecc6731fd7"
     ]
   ],
-  "_order": 229
+  "_order": 290
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.6cef18fad00d03a7.flows.js
+++ b/node-red/flows_js/change.6cef18fad00d03a7.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "54bea232f93f8f0b"
     ]
   ],
-  "_order": 172
+  "_order": 233
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.6d6145a3b97ad273.flows.js
+++ b/node-red/flows_js/change.6d6145a3b97ad273.flows.js
@@ -53,7 +53,7 @@ const Node = {
       "3103a50c2f18e075"
     ]
   ],
-  "_order": 263
+  "_order": 324
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.6ee1013da7bc9311.flows.js
+++ b/node-red/flows_js/change.6ee1013da7bc9311.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "6ee1013da7bc9311",
+  "type": "change",
+  "z": "80076417ef9f662a",
+  "name": "Create status object",
+  "rules": [
+    {
+      "t": "set",
+      "p": "status",
+      "pt": "msg",
+      "to": "{\t   \"fill\": \"yellow\",\t   \"shape\":\"ring\",\t   \"text\": \"Retries: \" & config.currentRetryAttempt\t}\t\t",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 640,
+  "y": 240,
+  "wires": [
+    [
+      "bf43302876766fa3"
+    ]
+  ],
+  "_order": 196
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.72ee09fd25a880d5.flows.js
+++ b/node-red/flows_js/change.72ee09fd25a880d5.flows.js
@@ -26,7 +26,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 214
+  "_order": 275
 }
 
 Node.info = `

--- a/node-red/flows_js/change.79d8b2a874c4987a.flows.js
+++ b/node-red/flows_js/change.79d8b2a874c4987a.flows.js
@@ -1,0 +1,35 @@
+const Node = {
+  "id": "79d8b2a874c4987a",
+  "type": "change",
+  "z": "80076417ef9f662a",
+  "name": "add delay + create schedule object \\n with cron expression",
+  "rules": [
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "(\t   /* Split the payload string into an array of time components */\t    $time_string_array := $split(payload, \":\");\t   /* Converts the time string array to a new array of numbers */\t    $time_number_array := $map(\t       $time_string_array,\t       function($value, $index) { $number($value) }\t   );\t   /* Calculates the new value for the minutes component by adding 2 if the seconds count is over 30 and 1 if it is under */\t    $nextrun_minutes := $time_number_array[1] + ($time_number_array[2] > 30 ? 2 : 1);\t    /* Generates the cron syntax */\t    $cron := $nextrun_minutes & \" \" & $time_number_array[0] & \" * * *\"\t   )",
+      "tot": "jsonata"
+    },
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "{\t    \"command\": \"add\",\t    \"name\": config.schedule_name,\t    \"expression\": payload,\t    \"expressionType\": \"cron\",\t    \"payloadType\": \"default\"\t}",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 1200,
+  "y": 120,
+  "wires": [
+    []
+  ],
+  "_order": 188
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.823f81c0457b06db.flows.js
+++ b/node-red/flows_js/change.823f81c0457b06db.flows.js
@@ -86,7 +86,7 @@ const Node = {
       "c606d977ccc17344"
     ]
   ],
-  "_order": 217
+  "_order": 278
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.85b6b60428bd1e4c.flows.js
+++ b/node-red/flows_js/change.85b6b60428bd1e4c.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "3e67a5def24cc8e4"
     ]
   ],
-  "_order": 183
+  "_order": 244
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.8f35b8f426ac7542.flows.js
+++ b/node-red/flows_js/change.8f35b8f426ac7542.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "5b1c780ffe35c1eb"
     ]
   ],
-  "_order": 235
+  "_order": 296
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.9e80d7b912c64137.flows.js
+++ b/node-red/flows_js/change.9e80d7b912c64137.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "5144e4be8fd69dbf"
     ]
   ],
-  "_order": 218
+  "_order": 279
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.a1025e65d5b222fa.flows.js
+++ b/node-red/flows_js/change.a1025e65d5b222fa.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "54c785a288809e11"
     ]
   ],
-  "_order": 166
+  "_order": 185
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.a1b312bc38e81c73.flows.js
+++ b/node-red/flows_js/change.a1b312bc38e81c73.flows.js
@@ -31,7 +31,7 @@ const Node = {
       "6a5e831da5abdd74"
     ]
   ],
-  "_order": 256
+  "_order": 317
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.a23b1d9fd52dfbdf.flows.js
+++ b/node-red/flows_js/change.a23b1d9fd52dfbdf.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "cd287725f072abe7"
     ]
   ],
-  "_order": 118
+  "_order": 137
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.ada1085ad5696009.flows.js
+++ b/node-red/flows_js/change.ada1085ad5696009.flows.js
@@ -1,0 +1,36 @@
+const Node = {
+  "id": "ada1085ad5696009",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Hent resultat",
+  "rules": [
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "payload.result.resources",
+      "tot": "msg"
+    },
+    {
+      "t": "delete",
+      "p": "url",
+      "pt": "msg"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 1230,
+  "y": 120,
+  "wires": [
+    [
+      "3acaac41151b641f"
+    ]
+  ],
+  "_order": 225
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.aec106ee16324493.flows.js
+++ b/node-red/flows_js/change.aec106ee16324493.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "698ef7d845c45259"
     ]
   ],
-  "_order": 238
+  "_order": 299
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.b2ba8b2d76e51db7.flows.js
+++ b/node-red/flows_js/change.b2ba8b2d76e51db7.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "758b1a3ab736cae5"
     ]
   ],
-  "_order": 157
+  "_order": 176
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.b340dcdc1c773927.flows.js
+++ b/node-red/flows_js/change.b340dcdc1c773927.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "b340dcdc1c773927",
+  "type": "change",
+  "z": "80076417ef9f662a",
+  "name": "currentRetryAttempt=1",
+  "rules": [
+    {
+      "t": "set",
+      "p": "config.currentRetryAttempt",
+      "pt": "msg",
+      "to": "1",
+      "tot": "num"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 380,
+  "y": 120,
+  "wires": [
+    [
+      "760ecf35e1a9bc7a"
+    ]
+  ],
+  "_order": 190
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.b5376498af36d2bd.flows.js
+++ b/node-red/flows_js/change.b5376498af36d2bd.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "b5376498af36d2bd",
+  "type": "change",
+  "z": "80076417ef9f662a",
+  "name": "currentRetryAttempt+1",
+  "rules": [
+    {
+      "t": "set",
+      "p": "config.currentRetryAttempt",
+      "pt": "msg",
+      "to": "config.currentRetryAttempt+1",
+      "tot": "jsonata"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 380,
+  "y": 80,
+  "wires": [
+    [
+      "760ecf35e1a9bc7a"
+    ]
+  ],
+  "_order": 191
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.b8b69a38c0aedf34.flows.js
+++ b/node-red/flows_js/change.b8b69a38c0aedf34.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "e330064ce7a79cc8"
     ]
   ],
-  "_order": 213
+  "_order": 274
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.b8d31274717de389.flows.js
+++ b/node-red/flows_js/change.b8d31274717de389.flows.js
@@ -1,0 +1,29 @@
+const Node = {
+  "id": "b8d31274717de389",
+  "type": "change",
+  "z": "16bb519c7f773542",
+  "g": "7a6becc707d70bf4",
+  "name": "fjern query",
+  "rules": [
+    {
+      "t": "delete",
+      "p": "topic",
+      "pt": "msg"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 550,
+  "y": 100,
+  "wires": [
+    [
+      "dd950470079df58a"
+    ]
+  ],
+  "_order": 202
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.b91ac275b4e70f51.flows.js
+++ b/node-red/flows_js/change.b91ac275b4e70f51.flows.js
@@ -1,0 +1,38 @@
+const Node = {
+  "id": "b91ac275b4e70f51",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "Opsætning af forespørgsel ↓ \\n Hent datafiler ",
+  "rules": [
+    {
+      "t": "set",
+      "p": "url",
+      "pt": "msg",
+      "to": "payload.url",
+      "tot": "jsonata"
+    },
+    {
+      "t": "set",
+      "p": "method",
+      "pt": "msg",
+      "to": "GET",
+      "tot": "str"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 260,
+  "y": 440,
+  "wires": [
+    [
+      "2eeba406d51ec3dd"
+    ]
+  ],
+  "_order": 212
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.ba6de20626a2f922.flows.js
+++ b/node-red/flows_js/change.ba6de20626a2f922.flows.js
@@ -86,7 +86,7 @@ const Node = {
       "6a2a56ca0f18b384"
     ]
   ],
-  "_order": 242
+  "_order": 303
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.bae7dd126b39e4a3.flows.js
+++ b/node-red/flows_js/change.bae7dd126b39e4a3.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "fc9b6e0147d4efe1"
     ]
   ],
-  "_order": 243
+  "_order": 304
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.bbcb5f39dd352e01.flows.js
+++ b/node-red/flows_js/change.bbcb5f39dd352e01.flows.js
@@ -28,7 +28,7 @@ const Node = {
       "02c42f1bea2e8afc"
     ]
   ],
-  "_order": 202
+  "_order": 263
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.be6eba4a03be6a16.flows.js
+++ b/node-red/flows_js/change.be6eba4a03be6a16.flows.js
@@ -1,0 +1,57 @@
+const Node = {
+  "id": "be6eba4a03be6a16",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Opsætning af forespørgsel ↓ \\n Hent metadata for \\n msg.dataset",
+  "rules": [
+    {
+      "t": "set",
+      "p": "url",
+      "pt": "msg",
+      "to": "https://admin.opendata.dk/api/3/action/package_show",
+      "tot": "str"
+    },
+    {
+      "t": "set",
+      "p": "method",
+      "pt": "msg",
+      "to": "POST",
+      "tot": "str"
+    },
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "{\"id\":\"\",\"include_tracking\":false,\"include_tracking_children\":false,\"sort\":\"resources.metadata_created asc\"}",
+      "tot": "json"
+    },
+    {
+      "t": "set",
+      "p": "payload.id",
+      "pt": "msg",
+      "to": "dataset",
+      "tot": "msg"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 540,
+  "y": 100,
+  "wires": [
+    [
+      "04f4a40ec54ef43e"
+    ]
+  ],
+  "info": "",
+  "_order": 221
+}
+
+Node.info = `
+https://www.opendata.dk/randers-kommune/antal-krydsende-cyklister-over-randers-fjord
+`
+
+module.exports = Node;

--- a/node-red/flows_js/change.bf76db2ac198b50b.flows.js
+++ b/node-red/flows_js/change.bf76db2ac198b50b.flows.js
@@ -24,7 +24,7 @@ const Node = {
       "3a3e26196ca3a21d"
     ]
   ],
-  "_order": 135
+  "_order": 154
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.c2a7d80a8df9fc53.flows.js
+++ b/node-red/flows_js/change.c2a7d80a8df9fc53.flows.js
@@ -25,7 +25,7 @@ const Node = {
       "2d9e69a26787f421"
     ]
   ],
-  "_order": 192
+  "_order": 253
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.c7afbc2c2d304e32.flows.js
+++ b/node-red/flows_js/change.c7afbc2c2d304e32.flows.js
@@ -32,7 +32,7 @@ const Node = {
       "a45d66223cdc33e2"
     ]
   ],
-  "_order": 106
+  "_order": 125
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.c9ceb3f69f2e739e.flows.js
+++ b/node-red/flows_js/change.c9ceb3f69f2e739e.flows.js
@@ -1,0 +1,52 @@
+const Node = {
+  "id": "c9ceb3f69f2e739e",
+  "type": "change",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Konfigurerer datatræks periode",
+  "rules": [
+    {
+      "t": "set",
+      "p": "max_file_age_days",
+      "pt": "msg",
+      "to": "$max_file_age_days := max_file_age_days ? max_file_age_days : 0 \t/* Sætter værdien til 0 hvis max_file_age_days er NULL eller ikke eksisterer */\t",
+      "tot": "jsonata"
+    },
+    {
+      "t": "set",
+      "p": "delay",
+      "pt": "msg",
+      "to": "0",
+      "tot": "num"
+    },
+    {
+      "t": "set",
+      "p": "data",
+      "pt": "msg",
+      "to": "{}",
+      "tot": "json"
+    },
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "{}",
+      "tot": "json"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 270,
+  "y": 100,
+  "wires": [
+    [
+      "be6eba4a03be6a16"
+    ]
+  ],
+  "_order": 220
+}
+
+module.exports = Node;

--- a/node-red/flows_js/change.ca29ff7c7dca1935.flows.js
+++ b/node-red/flows_js/change.ca29ff7c7dca1935.flows.js
@@ -46,7 +46,7 @@ const Node = {
       "24fba0b7beae16a9"
     ]
   ],
-  "_order": 159
+  "_order": 178
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.d5885d75e53926eb.flows.js
+++ b/node-red/flows_js/change.d5885d75e53926eb.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "90d08a0b2cd1e598"
     ]
   ],
-  "_order": 141
+  "_order": 160
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.e3e640d4700783e9.flows.js
+++ b/node-red/flows_js/change.e3e640d4700783e9.flows.js
@@ -24,7 +24,7 @@ const Node = {
       "6c9fbdb6055a96a8"
     ]
   ],
-  "_order": 131
+  "_order": 150
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.f0f28151b9339fac.flows.js
+++ b/node-red/flows_js/change.f0f28151b9339fac.flows.js
@@ -32,7 +32,7 @@ const Node = {
       "1f797d3ba95a0d9f"
     ]
   ],
-  "_order": 151
+  "_order": 170
 }
 
 module.exports = Node;

--- a/node-red/flows_js/change.f4bd6b60fe46c7ee.flows.js
+++ b/node-red/flows_js/change.f4bd6b60fe46c7ee.flows.js
@@ -1,0 +1,39 @@
+const Node = {
+  "id": "f4bd6b60fe46c7ee",
+  "type": "change",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "Skab dataskabelon",
+  "rules": [
+    {
+      "t": "set",
+      "p": "dataskabelon",
+      "pt": "msg",
+      "to": "data[0]",
+      "tot": "msg",
+      "dc": true
+    },
+    {
+      "t": "set",
+      "p": "payload",
+      "pt": "msg",
+      "to": "{}",
+      "tot": "json"
+    }
+  ],
+  "action": "",
+  "property": "",
+  "from": "",
+  "to": "",
+  "reg": false,
+  "x": 190,
+  "y": 400,
+  "wires": [
+    [
+      "070f0ec16e7893d0"
+    ]
+  ],
+  "_order": 337
+}
+
+module.exports = Node;

--- a/node-red/flows_js/cronplus.3a2c20021c59c43c.flows.js
+++ b/node-red/flows_js/cronplus.3a2c20021c59c43c.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "3af44629275ce741"
     ]
   ],
-  "_order": 185
+  "_order": 246
 }
 
 module.exports = Node;

--- a/node-red/flows_js/cronplus.49a382e63c795f8b.flows.js
+++ b/node-red/flows_js/cronplus.49a382e63c795f8b.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "eca4a640b3925439"
     ]
   ],
-  "_order": 190
+  "_order": 251
 }
 
 module.exports = Node;

--- a/node-red/flows_js/cronplus.5c265e4ca4ab11ea.flows.js
+++ b/node-red/flows_js/cronplus.5c265e4ca4ab11ea.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "ac5e094c99a67b2d"
     ]
   ],
-  "_order": 251
+  "_order": 312
 }
 
 module.exports = Node;

--- a/node-red/flows_js/cronplus.c1638c1915bee2ca.flows.js
+++ b/node-red/flows_js/cronplus.c1638c1915bee2ca.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "c680fc2ebd378756"
     ]
   ],
-  "_order": 266
+  "_order": 327
 }
 
 module.exports = Node;

--- a/node-red/flows_js/cronplus.dee8b7623e6d0ddd.flows.js
+++ b/node-red/flows_js/cronplus.dee8b7623e6d0ddd.flows.js
@@ -30,7 +30,7 @@ const Node = {
       "45577688ac957f99"
     ]
   ],
-  "_order": 226
+  "_order": 287
 }
 
 module.exports = Node;

--- a/node-red/flows_js/csv.005e3b79e2cf7c32.flows.js
+++ b/node-red/flows_js/csv.005e3b79e2cf7c32.flows.js
@@ -1,0 +1,27 @@
+const Node = {
+  "id": "005e3b79e2cf7c32",
+  "type": "csv",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "",
+  "sep": ";",
+  "hdrin": true,
+  "hdrout": "all",
+  "multi": "mult",
+  "ret": "\\n",
+  "temp": "",
+  "skip": "0",
+  "strings": true,
+  "include_empty_strings": "",
+  "include_null_values": "",
+  "x": 850,
+  "y": 420,
+  "wires": [
+    [
+      "66b59f8b5f624673"
+    ]
+  ],
+  "_order": 214
+}
+
+module.exports = Node;

--- a/node-red/flows_js/csv.7d50abf0d3091c7b.flows.js
+++ b/node-red/flows_js/csv.7d50abf0d3091c7b.flows.js
@@ -21,7 +21,7 @@ const Node = {
       "54ac54f14b340491"
     ]
   ],
-  "_order": 108
+  "_order": 127
 }
 
 module.exports = Node;

--- a/node-red/flows_js/csv.882797cfacc7ff7c.flows.js
+++ b/node-red/flows_js/csv.882797cfacc7ff7c.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "4b86f589fd76f9d5"
     ]
   ],
-  "_order": 171
+  "_order": 232
 }
 
 module.exports = Node;

--- a/node-red/flows_js/csv.90b5f43d586b5bfe.flows.js
+++ b/node-red/flows_js/csv.90b5f43d586b5bfe.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "a2685221cb05fc5a"
     ]
   ],
-  "_order": 197
+  "_order": 258
 }
 
 module.exports = Node;

--- a/node-red/flows_js/csv.a99e5a07925df8f2.flows.js
+++ b/node-red/flows_js/csv.a99e5a07925df8f2.flows.js
@@ -21,7 +21,7 @@ const Node = {
       "b2ba8b2d76e51db7"
     ]
   ],
-  "_order": 153
+  "_order": 172
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.00864b74fec3e5b7.flows.js
+++ b/node-red/flows_js/debug.00864b74fec3e5b7.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1420,
   "y": 120,
   "wires": [],
-  "_order": 249
+  "_order": 310
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.0b66b7189377295c.flows.js
+++ b/node-red/flows_js/debug.0b66b7189377295c.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 780,
   "y": 760,
   "wires": [],
-  "_order": 223
+  "_order": 284
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.16b18d3edc4d442f.flows.js
+++ b/node-red/flows_js/debug.16b18d3edc4d442f.flows.js
@@ -1,0 +1,20 @@
+const Node = {
+  "id": "16b18d3edc4d442f",
+  "type": "debug",
+  "z": "16bb519c7f773542",
+  "g": "7a6becc707d70bf4",
+  "name": "debug 27",
+  "active": false,
+  "tosidebar": true,
+  "console": false,
+  "tostatus": false,
+  "complete": "false",
+  "statusVal": "",
+  "statusType": "auto",
+  "x": 700,
+  "y": 60,
+  "wires": [],
+  "_order": 200
+}
+
+module.exports = Node;

--- a/node-red/flows_js/debug.2123bf14edf858cc.flows.js
+++ b/node-red/flows_js/debug.2123bf14edf858cc.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 860,
   "y": 640,
   "wires": [],
-  "_order": 180
+  "_order": 241
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.3f641fcece5a6ba2.flows.js
+++ b/node-red/flows_js/debug.3f641fcece5a6ba2.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "x": 1270,
   "y": 500,
   "wires": [],
-  "_order": 189
+  "_order": 250
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.4057cf82e6442f23.flows.js
+++ b/node-red/flows_js/debug.4057cf82e6442f23.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1420,
   "y": 120,
   "wires": [],
-  "_order": 182
+  "_order": 243
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.5d96150bfa192fe7.flows.js
+++ b/node-red/flows_js/debug.5d96150bfa192fe7.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1420,
   "y": 120,
   "wires": [],
-  "_order": 224
+  "_order": 285
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.629fadbe2ccd3132.flows.js
+++ b/node-red/flows_js/debug.629fadbe2ccd3132.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1360,
   "y": 229,
   "wires": [],
-  "_order": 257
+  "_order": 318
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.64725cf513a36044.flows.js
+++ b/node-red/flows_js/debug.64725cf513a36044.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1349,
   "y": 286,
   "wires": [],
-  "_order": 258
+  "_order": 319
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.77b93de03ab58823.flows.js
+++ b/node-red/flows_js/debug.77b93de03ab58823.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1040,
   "y": 460,
   "wires": [],
-  "_order": 210
+  "_order": 271
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.b747aa1f23624263.flows.js
+++ b/node-red/flows_js/debug.b747aa1f23624263.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1040,
   "y": 460,
   "wires": [],
-  "_order": 233
+  "_order": 294
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.ba90debab3691911.flows.js
+++ b/node-red/flows_js/debug.ba90debab3691911.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 860,
   "y": 640,
   "wires": [],
-  "_order": 206
+  "_order": 267
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.c5d4ecc27825ec66.flows.js
+++ b/node-red/flows_js/debug.c5d4ecc27825ec66.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1080,
   "y": 440,
   "wires": [],
-  "_order": 179
+  "_order": 240
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.c6673a134c929996.flows.js
+++ b/node-red/flows_js/debug.c6673a134c929996.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1180,
   "y": 440,
   "wires": [],
-  "_order": 205
+  "_order": 266
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.c67629cbfb8b8373.flows.js
+++ b/node-red/flows_js/debug.c67629cbfb8b8373.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 700,
   "y": 60,
   "wires": [],
-  "_order": 101
+  "_order": 120
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.d31a7e940eaf4733.flows.js
+++ b/node-red/flows_js/debug.d31a7e940eaf4733.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 1420,
   "y": 120,
   "wires": [],
-  "_order": 204
+  "_order": 265
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.e787251a67b6e815.flows.js
+++ b/node-red/flows_js/debug.e787251a67b6e815.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 780,
   "y": 760,
   "wires": [],
-  "_order": 234
+  "_order": 295
 }
 
 module.exports = Node;

--- a/node-red/flows_js/debug.f6a044c673cfcc7a.flows.js
+++ b/node-red/flows_js/debug.f6a044c673cfcc7a.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "x": 700,
   "y": 60,
   "wires": [],
-  "_order": 139
+  "_order": 158
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.077bfbcc6043bdb1.flows.js
+++ b/node-red/flows_js/delay.077bfbcc6043bdb1.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 194
+  "_order": 255
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.1f797d3ba95a0d9f.flows.js
+++ b/node-red/flows_js/delay.1f797d3ba95a0d9f.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 155
+  "_order": 174
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.2eeba406d51ec3dd.flows.js
+++ b/node-red/flows_js/delay.2eeba406d51ec3dd.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "2eeba406d51ec3dd",
+  "type": "delay",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "",
+  "pauseType": "rate",
+  "timeout": "5",
+  "timeoutUnits": "seconds",
+  "rate": "5",
+  "nbRateUnits": "1",
+  "rateUnits": "second",
+  "randomFirst": "1",
+  "randomLast": "5",
+  "randomUnits": "seconds",
+  "drop": false,
+  "allowrate": false,
+  "outputs": 1,
+  "x": 435,
+  "y": 440,
+  "wires": [
+    [
+      "beb144e0d6ad11a8"
+    ]
+  ],
+  "l": false,
+  "_order": 216
+}
+
+module.exports = Node;

--- a/node-red/flows_js/delay.37c93df8cc9511ca.flows.js
+++ b/node-red/flows_js/delay.37c93df8cc9511ca.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 246
+  "_order": 307
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.6fe4579af68bd2ea.flows.js
+++ b/node-red/flows_js/delay.6fe4579af68bd2ea.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "0f58b58f8df7f5e7"
     ]
   ],
-  "_order": 120
+  "_order": 139
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.a45d66223cdc33e2.flows.js
+++ b/node-red/flows_js/delay.a45d66223cdc33e2.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 110
+  "_order": 129
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.aa4085ae631b7f7f.flows.js
+++ b/node-red/flows_js/delay.aa4085ae631b7f7f.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 169
+  "_order": 230
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.e5361e70221c8772.flows.js
+++ b/node-red/flows_js/delay.e5361e70221c8772.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "1f2e5cdec5771807"
     ]
   ],
-  "_order": 121
+  "_order": 140
 }
 
 module.exports = Node;

--- a/node-red/flows_js/delay.ea6b9ddd404c6bfa.flows.js
+++ b/node-red/flows_js/delay.ea6b9ddd404c6bfa.flows.js
@@ -24,7 +24,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 221
+  "_order": 282
 }
 
 module.exports = Node;

--- a/node-red/flows_js/function.070f0ec16e7893d0.flows.js
+++ b/node-red/flows_js/function.070f0ec16e7893d0.flows.js
@@ -1,0 +1,68 @@
+const Node = {
+  "id": "070f0ec16e7893d0",
+  "type": "function",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "suggestSqlDataType",
+  "func": "",
+  "outputs": 1,
+  "noerr": 0,
+  "initialize": "",
+  "finalize": "",
+  "libs": [],
+  "x": 400,
+  "y": 400,
+  "wires": [
+    [
+      "c0a1ad499d5c94df"
+    ]
+  ],
+  "_order": 331
+}
+
+Node.func = async function (node, msg, RED, context, flow, global, env, util) {
+  // Function to suggest SQL datatype based on string content
+  function suggestSqlDataType(value) {
+      // Try to parse value as integer
+      if (Number.isInteger(Number(value))) {
+          return "INTEGER";
+      }
+  
+      // Try to parse value as floating-point number
+      if (!isNaN(parseFloat(value))) {
+          return "FLOAT";
+      }
+  
+      // Check if value is a date string in the format "YYYY-MM-DD"
+      if (/^\d{4}-\d{2}-\d{2\}$/.test(value)) {
+          return "DATE";
+      }
+  
+      // Check if value is a date-time string in the format "YYYY-MM-DDTHH:mm:ss"
+      if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$/.test(value)) {
+          return "DATETIME";
+      }
+  
+      // Default to VARCHAR with a length of 255 characters
+      return "VARCHAR(255)";
+  }
+  
+  // Initialize msg.sqlDataType as an empty object
+  msg.payload.sqlDataType = {};
+  
+  // Initialize msg.flatlist as an empty array
+  msg.payload.flatlist = [];
+  
+  // Iterate through the input JSON object and suggest SQL datatype for each value
+  for (var key in msg.dataskabelon) {
+      if (msg.dataskabelon.hasOwnProperty(key)) {
+          msg.payload.sqlDataType[key] = suggestSqlDataType(msg.dataskabelon[key]);
+          msg.payload.flatlist.push({ "name": key, "type": msg.payload.sqlDataType[key] });
+      }
+  }
+  
+  return msg;
+  
+}
+
+module.exports = Node;

--- a/node-red/flows_js/function.1cbaf9dd5f00f15d.flows.js
+++ b/node-red/flows_js/function.1cbaf9dd5f00f15d.flows.js
@@ -1,0 +1,26 @@
+const Node = {
+  "id": "1cbaf9dd5f00f15d",
+  "type": "function",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Set Status",
+  "func": "",
+  "outputs": 1,
+  "noerr": 0,
+  "initialize": "",
+  "finalize": "",
+  "libs": [],
+  "x": 1370,
+  "y": 60,
+  "wires": [
+    []
+  ],
+  "_order": 228
+}
+
+Node.func = async function (node, msg, RED, context, flow, global, env, util) {
+  node.status({ fill: msg.status.fill, shape: msg.status.shape, text: msg.status.text });
+  return msg;
+}
+
+module.exports = Node;

--- a/node-red/flows_js/function.3a3e26196ca3a21d.flows.js
+++ b/node-red/flows_js/function.3a3e26196ca3a21d.flows.js
@@ -14,7 +14,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 134
+  "_order": 153
 }
 
 Node.func = async function (node, msg, RED, context, flow, global, env, util) {

--- a/node-red/flows_js/function.54c785a288809e11.flows.js
+++ b/node-red/flows_js/function.54c785a288809e11.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 167
+  "_order": 186
 }
 
 Node.func = async function (node, msg, RED, context, flow, global, env, util) {

--- a/node-red/flows_js/function.6c9fbdb6055a96a8.flows.js
+++ b/node-red/flows_js/function.6c9fbdb6055a96a8.flows.js
@@ -16,7 +16,7 @@ const Node = {
       "3213d6b6dcbc1775"
     ]
   ],
-  "_order": 132
+  "_order": 151
 }
 
 Node.func = async function (node, msg, RED, context, flow, global, env, util) {

--- a/node-red/flows_js/function.912cd2c68d0d95f1.flows.js
+++ b/node-red/flows_js/function.912cd2c68d0d95f1.flows.js
@@ -1,0 +1,43 @@
+const Node = {
+  "id": "912cd2c68d0d95f1",
+  "type": "function",
+  "z": "80076417ef9f662a",
+  "name": "Add timezone to timestamp",
+  "func": "",
+  "outputs": 1,
+  "noerr": 0,
+  "initialize": "",
+  "finalize": "",
+  "libs": [],
+  "x": 900,
+  "y": 120,
+  "wires": [
+    [
+      "79d8b2a874c4987a"
+    ]
+  ],
+  "_order": 193
+}
+
+Node.func = async function (node, msg, RED, context, flow, global, env, util) {
+  // Define options for the date format
+  const options = {
+      timeZone: msg.config.timezone // Set the timezone from the message configuration
+  };
+  
+  // Get the timestamp from the message payload
+  const timestamp = msg.payload;
+  
+  // Create a new Date object using the timestamp,
+  // and format it as a time string using the specified options
+  // The 'en-GB' locale is used to match the cron syntax with colons between numbers
+  var date = new Date(timestamp).toLocaleTimeString('en-GB', options);
+  
+  // Update the message payload with the formatted date
+  msg.payload = date;
+  
+  // Return the updated message
+  return msg;
+}
+
+module.exports = Node;

--- a/node-red/flows_js/function.bf43302876766fa3.flows.js
+++ b/node-red/flows_js/function.bf43302876766fa3.flows.js
@@ -1,0 +1,25 @@
+const Node = {
+  "id": "bf43302876766fa3",
+  "type": "function",
+  "z": "80076417ef9f662a",
+  "name": "Set Status",
+  "func": "",
+  "outputs": 1,
+  "noerr": 0,
+  "initialize": "",
+  "finalize": "",
+  "libs": [],
+  "x": 610,
+  "y": 280,
+  "wires": [
+    []
+  ],
+  "_order": 195
+}
+
+Node.func = async function (node, msg, RED, context, flow, global, env, util) {
+  node.status({ fill: msg.status.fill, shape: msg.status.shape, text: msg.status.text });
+  return msg;
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.0b6a3796775ca5e9.flows.js
+++ b/node-red/flows_js/group.0b6a3796775ca5e9.flows.js
@@ -18,7 +18,7 @@ const Node = {
   ],
   "x": 114,
   "y": 239,
-  "_order": 21
+  "_order": 24
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.0ec48b0df0503cd8.flows.js
+++ b/node-red/flows_js/group.0ec48b0df0503cd8.flows.js
@@ -16,7 +16,7 @@ const Node = {
   ],
   "x": 114,
   "y": 567,
-  "_order": 12
+  "_order": 15
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.0f369eeef0896547.flows.js
+++ b/node-red/flows_js/group.0f369eeef0896547.flows.js
@@ -21,7 +21,7 @@ const Node = {
   ],
   "x": 114,
   "y": 35,
-  "_order": 33
+  "_order": 36
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.12de71dcddfdf75d.flows.js
+++ b/node-red/flows_js/group.12de71dcddfdf75d.flows.js
@@ -1,0 +1,27 @@
+const Node = {
+  "id": "12de71dcddfdf75d",
+  "type": "group",
+  "z": "6b360b454d19172a",
+  "name": "Forespørgsel til admin.opendata.dj",
+  "style": {
+    "stroke": "none",
+    "fill": "#e3f3d3",
+    "fill-opacity": "0.52",
+    "label": true
+  },
+  "nodes": [
+    "b91ac275b4e70f51",
+    "beb144e0d6ad11a8",
+    "005e3b79e2cf7c32",
+    "a87301fa2a0d3ad8",
+    "2eeba406d51ec3dd",
+    "b6f6580c94e57efa",
+    "66b59f8b5f624673",
+    "d724de646703fe6a"
+  ],
+  "x": 114,
+  "y": 379,
+  "_order": 50
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.19fc61772af3f2a5.flows.js
+++ b/node-red/flows_js/group.19fc61772af3f2a5.flows.js
@@ -15,7 +15,7 @@ const Node = {
   ],
   "x": 114,
   "y": 247,
-  "_order": 38
+  "_order": 41
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.2e3370dafaa81dac.flows.js
+++ b/node-red/flows_js/group.2e3370dafaa81dac.flows.js
@@ -22,7 +22,7 @@ const Node = {
   ],
   "x": 114,
   "y": 379,
-  "_order": 34
+  "_order": 37
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.35227f630a1419d4.flows.js
+++ b/node-red/flows_js/group.35227f630a1419d4.flows.js
@@ -15,7 +15,7 @@ const Node = {
   ],
   "x": 114,
   "y": 247,
-  "_order": 35
+  "_order": 38
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.3747d27918090082.flows.js
+++ b/node-red/flows_js/group.3747d27918090082.flows.js
@@ -19,7 +19,7 @@ const Node = {
   "y": 39,
   "w": 342,
   "h": 122,
-  "_order": 43
+  "_order": 46
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.420f87762af87ac6.flows.js
+++ b/node-red/flows_js/group.420f87762af87ac6.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 47,
-  "_order": 26
+  "_order": 29
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.4d967bbe9d19abb4.flows.js
+++ b/node-red/flows_js/group.4d967bbe9d19abb4.flows.js
@@ -1,0 +1,21 @@
+const Node = {
+  "id": "4d967bbe9d19abb4",
+  "type": "group",
+  "z": "6b360b454d19172a",
+  "name": "Datafilter data_age_days",
+  "style": {
+    "stroke": "none",
+    "fill": "#ffefbf",
+    "fill-opacity": "0.5",
+    "label": true
+  },
+  "nodes": [
+    "b569417d9c845b0f",
+    "503e7c1fc3fe9500"
+  ],
+  "x": 114,
+  "y": 247,
+  "_order": 48
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.551ed5c8ce0f31c7.flows.js
+++ b/node-red/flows_js/group.551ed5c8ce0f31c7.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 255,
-  "_order": 20
+  "_order": 23
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.558021ee7e67a81d.flows.js
+++ b/node-red/flows_js/group.558021ee7e67a81d.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 695,
-  "_order": 13
+  "_order": 16
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.5b468bd526d63108.flows.js
+++ b/node-red/flows_js/group.5b468bd526d63108.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 794,
   "y": 239,
-  "_order": 39
+  "_order": 42
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.616fd052c81e52cc.flows.js
+++ b/node-red/flows_js/group.616fd052c81e52cc.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 47,
-  "_order": 32
+  "_order": 35
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.61c8622d890b37d9.flows.js
+++ b/node-red/flows_js/group.61c8622d890b37d9.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 695,
-  "_order": 24
+  "_order": 27
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.62d1b4969e322491.flows.js
+++ b/node-red/flows_js/group.62d1b4969e322491.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 614,
   "y": 55,
-  "_order": 27
+  "_order": 30
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.68638907faf95219.flows.js
+++ b/node-red/flows_js/group.68638907faf95219.flows.js
@@ -19,7 +19,7 @@ const Node = {
   ],
   "x": 114,
   "y": 414,
-  "_order": 18
+  "_order": 21
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.6aa95c95913a1dc8.flows.js
+++ b/node-red/flows_js/group.6aa95c95913a1dc8.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 614,
   "y": 55,
-  "_order": 31
+  "_order": 34
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.775f1511bb6470f8.flows.js
+++ b/node-red/flows_js/group.775f1511bb6470f8.flows.js
@@ -20,7 +20,7 @@ const Node = {
   ],
   "x": 194,
   "y": 19,
-  "_order": 25
+  "_order": 28
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.7a6becc707d70bf4.flows.js
+++ b/node-red/flows_js/group.7a6becc707d70bf4.flows.js
@@ -1,0 +1,26 @@
+const Node = {
+  "id": "7a6becc707d70bf4",
+  "type": "group",
+  "z": "16bb519c7f773542",
+  "name": "Database connector",
+  "style": {
+    "stroke": "none",
+    "stroke-opacity": "0.5",
+    "fill": "#bfc7d7",
+    "fill-opacity": "0.51",
+    "label": true,
+    "color": "#3f3f3f"
+  },
+  "nodes": [
+    "afac8653d4fb392b",
+    "16b18d3edc4d442f",
+    "2d2c9c09066d17ba",
+    "b8d31274717de389",
+    "dd950470079df58a"
+  ],
+  "x": 194,
+  "y": 19,
+  "_order": 47
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.7b1390c441209648.flows.js
+++ b/node-red/flows_js/group.7b1390c441209648.flows.js
@@ -18,7 +18,7 @@ const Node = {
   ],
   "x": 114,
   "y": 414,
-  "_order": 16
+  "_order": 19
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.7c67278750086864.flows.js
+++ b/node-red/flows_js/group.7c67278750086864.flows.js
@@ -21,7 +21,7 @@ const Node = {
   ],
   "x": 114,
   "y": 379,
-  "_order": 40
+  "_order": 43
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.7c7a1adb80186cae.flows.js
+++ b/node-red/flows_js/group.7c7a1adb80186cae.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 614,
   "y": 55,
-  "_order": 14
+  "_order": 17
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.7fe3437fd75f09f8.flows.js
+++ b/node-red/flows_js/group.7fe3437fd75f09f8.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 575,
-  "_order": 17
+  "_order": 20
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.80e6cc7cb0d92329.flows.js
+++ b/node-red/flows_js/group.80e6cc7cb0d92329.flows.js
@@ -1,0 +1,30 @@
+const Node = {
+  "id": "80e6cc7cb0d92329",
+  "type": "group",
+  "z": "452aaf8dc5cd8d45",
+  "name": "Datalake generator",
+  "style": {
+    "label": true,
+    "stroke": "none",
+    "stroke-opacity": "0.51",
+    "fill": "#bfdbef",
+    "fill-opacity": "0.55"
+  },
+  "nodes": [
+    "070f0ec16e7893d0",
+    "c0a1ad499d5c94df",
+    "38291a57af9afb3e",
+    "cc4372cb27df1b3d",
+    "6599492760ca4710",
+    "1adb98814879c48c",
+    "f4bd6b60fe46c7ee",
+    "4587d61d62e5e743"
+  ],
+  "x": 74,
+  "y": 359,
+  "w": 972,
+  "h": 206,
+  "_order": 52
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.8373144d65750968.flows.js
+++ b/node-red/flows_js/group.8373144d65750968.flows.js
@@ -18,7 +18,7 @@ const Node = {
   ],
   "x": 114,
   "y": 434,
-  "_order": 11
+  "_order": 14
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.94f2534250740b77.flows.js
+++ b/node-red/flows_js/group.94f2534250740b77.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 575,
-  "_order": 15
+  "_order": 18
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.992b69685929fd28.flows.js
+++ b/node-red/flows_js/group.992b69685929fd28.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 255,
-  "_order": 19
+  "_order": 22
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.aba12498e68c82c2.flows.js
+++ b/node-red/flows_js/group.aba12498e68c82c2.flows.js
@@ -18,7 +18,7 @@ const Node = {
   ],
   "x": 114,
   "y": 434,
-  "_order": 22
+  "_order": 25
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.acc1c82d640f13f3.flows.js
+++ b/node-red/flows_js/group.acc1c82d640f13f3.flows.js
@@ -23,7 +23,7 @@ const Node = {
   ],
   "x": 114,
   "y": 19,
-  "_order": 41
+  "_order": 44
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.ae64c3f2c1c354b3.flows.js
+++ b/node-red/flows_js/group.ae64c3f2c1c354b3.flows.js
@@ -1,0 +1,23 @@
+const Node = {
+  "id": "ae64c3f2c1c354b3",
+  "type": "group",
+  "z": "6b360b454d19172a",
+  "name": "Metrics",
+  "style": {
+    "stroke": "none",
+    "fill": "#dbcbe7",
+    "fill-opacity": "0.5",
+    "label": true
+  },
+  "nodes": [
+    "bb89ca1a3f3c4750",
+    "e1e6ba7375f49afd",
+    "a713818e03fcf4ec",
+    "2e39b79d2576f9ba"
+  ],
+  "x": 794,
+  "y": 239,
+  "_order": 49
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.aedcfef7c781f318.flows.js
+++ b/node-red/flows_js/group.aedcfef7c781f318.flows.js
@@ -22,7 +22,7 @@ const Node = {
   "y": 159,
   "w": 772,
   "h": 162,
-  "_order": 42
+  "_order": 45
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.bb671390488c23f1.flows.js
+++ b/node-red/flows_js/group.bb671390488c23f1.flows.js
@@ -1,0 +1,29 @@
+const Node = {
+  "id": "bb671390488c23f1",
+  "type": "group",
+  "z": "6b360b454d19172a",
+  "name": "Forespørgsel til admin.opendata.dk",
+  "style": {
+    "stroke": "none",
+    "fill": "#e3f3d3",
+    "fill-opacity": "0.5",
+    "label": true
+  },
+  "nodes": [
+    "c9ceb3f69f2e739e",
+    "be6eba4a03be6a16",
+    "04f4a40ec54ef43e",
+    "eec02a801697c1a2",
+    "dc172905d7889d81",
+    "ada1085ad5696009",
+    "1edfd2ca9d9adb45",
+    "0f9cc8245b0bfdac",
+    "1cbaf9dd5f00f15d",
+    "3a1d337255c7e207"
+  ],
+  "x": 114,
+  "y": 19,
+  "_order": 51
+}
+
+module.exports = Node;

--- a/node-red/flows_js/group.bc26321d5a43933d.flows.js
+++ b/node-red/flows_js/group.bc26321d5a43933d.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 654,
   "y": 239,
-  "_order": 36
+  "_order": 39
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.c2dc80545b058de8.flows.js
+++ b/node-red/flows_js/group.c2dc80545b058de8.flows.js
@@ -20,7 +20,7 @@ const Node = {
   ],
   "x": 194,
   "y": 19,
-  "_order": 37
+  "_order": 40
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.c48edeb2197fb965.flows.js
+++ b/node-red/flows_js/group.c48edeb2197fb965.flows.js
@@ -16,7 +16,7 @@ const Node = {
   ],
   "x": 114,
   "y": 567,
-  "_order": 23
+  "_order": 26
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.ca8ecf0bcc98d479.flows.js
+++ b/node-red/flows_js/group.ca8ecf0bcc98d479.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 47,
-  "_order": 30
+  "_order": 33
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.d7a0dc9f17f84cd2.flows.js
+++ b/node-red/flows_js/group.d7a0dc9f17f84cd2.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 614,
   "y": 55,
-  "_order": 29
+  "_order": 32
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.dce8b91a0662f793.flows.js
+++ b/node-red/flows_js/group.dce8b91a0662f793.flows.js
@@ -17,7 +17,7 @@ const Node = {
   ],
   "x": 114,
   "y": 47,
-  "_order": 28
+  "_order": 31
 }
 
 module.exports = Node;

--- a/node-red/flows_js/group.e927759a0e35212b.flows.js
+++ b/node-red/flows_js/group.e927759a0e35212b.flows.js
@@ -18,7 +18,7 @@ const Node = {
   ],
   "x": 114,
   "y": 239,
-  "_order": 10
+  "_order": 13
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.04f4a40ec54ef43e.flows.js
+++ b/node-red/flows_js/http_request.04f4a40ec54ef43e.flows.js
@@ -1,0 +1,29 @@
+const Node = {
+  "id": "04f4a40ec54ef43e",
+  "type": "http request",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Send forespørgsel",
+  "method": "use",
+  "ret": "txt",
+  "paytoqs": "ignore",
+  "url": "",
+  "tls": "5c13e4731fd7f4cf",
+  "persist": false,
+  "proxy": "",
+  "insecureHTTPParser": false,
+  "authType": "",
+  "senderr": false,
+  "headers": [],
+  "x": 810,
+  "y": 80,
+  "wires": [
+    [
+      "eec02a801697c1a2",
+      "3a1d337255c7e207"
+    ]
+  ],
+  "_order": 222
+}
+
+module.exports = Node;

--- a/node-red/flows_js/http_request.2572a9725c8bd282.flows.js
+++ b/node-red/flows_js/http_request.2572a9725c8bd282.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "4570c6c9a34474fa"
     ]
   ],
-  "_order": 177
+  "_order": 238
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.5a0352bb0b5135ef.flows.js
+++ b/node-red/flows_js/http_request.5a0352bb0b5135ef.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "ead0a5539c5bb1b9"
     ]
   ],
-  "_order": 216
+  "_order": 277
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.675d300aedfe46e9.flows.js
+++ b/node-red/flows_js/http_request.675d300aedfe46e9.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "d09e9abbc38df8c5"
     ]
   ],
-  "_order": 115
+  "_order": 134
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.a23d55dbf287fcfa.flows.js
+++ b/node-red/flows_js/http_request.a23d55dbf287fcfa.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "bbcb5f39dd352e01"
     ]
   ],
-  "_order": 203
+  "_order": 264
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.beaf5d92aadafebc.flows.js
+++ b/node-red/flows_js/http_request.beaf5d92aadafebc.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "9ebe4442caf07207"
     ]
   ],
-  "_order": 152
+  "_order": 171
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.beb144e0d6ad11a8.flows.js
+++ b/node-red/flows_js/http_request.beb144e0d6ad11a8.flows.js
@@ -1,0 +1,28 @@
+const Node = {
+  "id": "beb144e0d6ad11a8",
+  "type": "http request",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "Send forespørgsel",
+  "method": "use",
+  "ret": "txt",
+  "paytoqs": "ignore",
+  "url": "",
+  "tls": "5c13e4731fd7f4cf",
+  "persist": false,
+  "proxy": "",
+  "insecureHTTPParser": false,
+  "authType": "",
+  "senderr": false,
+  "headers": [],
+  "x": 610,
+  "y": 420,
+  "wires": [
+    [
+      "b6f6580c94e57efa"
+    ]
+  ],
+  "_order": 213
+}
+
+module.exports = Node;

--- a/node-red/flows_js/http_request.efa60fc4e74417d8.flows.js
+++ b/node-red/flows_js/http_request.efa60fc4e74417d8.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "22ee05fb2aa11f3b"
     ]
   ],
-  "_order": 107
+  "_order": 126
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.f79f6d8ada4f88fc.flows.js
+++ b/node-red/flows_js/http_request.f79f6d8ada4f88fc.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "4ef6f0b5052e89da"
     ]
   ],
-  "_order": 161
+  "_order": 180
 }
 
 module.exports = Node;

--- a/node-red/flows_js/http_request.f934320bfabf4b28.flows.js
+++ b/node-red/flows_js/http_request.f934320bfabf4b28.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "12af887fa3e97f37"
     ]
   ],
-  "_order": 241
+  "_order": 302
 }
 
 module.exports = Node;

--- a/node-red/flows_js/inject.03cb13cd415ca430.flows.js
+++ b/node-red/flows_js/inject.03cb13cd415ca430.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "7e95b253cad342a4"
     ]
   ],
-  "_order": 227
+  "_order": 288
 }
 
 module.exports = Node;

--- a/node-red/flows_js/inject.1e0bb0ba8b707c57.flows.js
+++ b/node-red/flows_js/inject.1e0bb0ba8b707c57.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "59b47841deed3db1"
     ]
   ],
-  "_order": 252
+  "_order": 313
 }
 
 module.exports = Node;

--- a/node-red/flows_js/inject.749aa694f4c979f3.flows.js
+++ b/node-red/flows_js/inject.749aa694f4c979f3.flows.js
@@ -22,7 +22,7 @@ const Node = {
       "2acfab588074f57d"
     ]
   ],
-  "_order": 267
+  "_order": 328
 }
 
 module.exports = Node;

--- a/node-red/flows_js/inject.9c5256e50882b0af.flows.js
+++ b/node-red/flows_js/inject.9c5256e50882b0af.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "7a9038c6f798cfa3"
     ]
   ],
-  "_order": 191
+  "_order": 252
 }
 
 module.exports = Node;

--- a/node-red/flows_js/inject.d70c9a3e0a47a186.flows.js
+++ b/node-red/flows_js/inject.d70c9a3e0a47a186.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "7278d8a019646c2b"
     ]
   ],
-  "_order": 186
+  "_order": 247
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.0e0f9df272dc5fc1.flows.js
+++ b/node-red/flows_js/join.0e0f9df272dc5fc1.flows.js
@@ -26,7 +26,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 175
+  "_order": 236
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.273cf4f3b5ad8b9d.flows.js
+++ b/node-red/flows_js/join.273cf4f3b5ad8b9d.flows.js
@@ -27,7 +27,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 247
+  "_order": 308
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.69dbd2a0eb7ccecd.flows.js
+++ b/node-red/flows_js/join.69dbd2a0eb7ccecd.flows.js
@@ -27,7 +27,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 222
+  "_order": 283
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.8517e1ef1f306cd4.flows.js
+++ b/node-red/flows_js/join.8517e1ef1f306cd4.flows.js
@@ -27,7 +27,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 195
+  "_order": 256
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.8625b2fab96ba8e9.flows.js
+++ b/node-red/flows_js/join.8625b2fab96ba8e9.flows.js
@@ -26,7 +26,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 200
+  "_order": 261
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.9eb71b7a3795cc96.flows.js
+++ b/node-red/flows_js/join.9eb71b7a3795cc96.flows.js
@@ -27,7 +27,7 @@ const Node = {
     ]
   ],
   "l": false,
-  "_order": 170
+  "_order": 231
 }
 
 module.exports = Node;

--- a/node-red/flows_js/join.e70a1104df57dfc9.flows.js
+++ b/node-red/flows_js/join.e70a1104df57dfc9.flows.js
@@ -27,7 +27,7 @@ const Node = {
       "0ef69341b2942667"
     ]
   ],
-  "_order": 260
+  "_order": 321
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.0762afa37654a230.flows.js
+++ b/node-red/flows_js/json.0762afa37654a230.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "376236699fa4f2cc"
     ]
   ],
-  "_order": 163
+  "_order": 182
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.276139171fd46b7f.flows.js
+++ b/node-red/flows_js/json.276139171fd46b7f.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "a23b1d9fd52dfbdf"
     ]
   ],
-  "_order": 117
+  "_order": 136
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.29054ef492b57967.flows.js
+++ b/node-red/flows_js/json.29054ef492b57967.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "f6a044c673cfcc7a"
     ]
   ],
-  "_order": 140
+  "_order": 159
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.2d2c9c09066d17ba.flows.js
+++ b/node-red/flows_js/json.2d2c9c09066d17ba.flows.js
@@ -1,0 +1,20 @@
+const Node = {
+  "id": "2d2c9c09066d17ba",
+  "type": "json",
+  "z": "16bb519c7f773542",
+  "g": "7a6becc707d70bf4",
+  "name": "",
+  "property": "payload",
+  "action": "",
+  "pretty": false,
+  "x": 530,
+  "y": 60,
+  "wires": [
+    [
+      "16b18d3edc4d442f"
+    ]
+  ],
+  "_order": 201
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.321ce2c6e7eb1091.flows.js
+++ b/node-red/flows_js/json.321ce2c6e7eb1091.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "c67629cbfb8b8373"
     ]
   ],
-  "_order": 102
+  "_order": 121
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.3a1d337255c7e207.flows.js
+++ b/node-red/flows_js/json.3a1d337255c7e207.flows.js
@@ -1,0 +1,20 @@
+const Node = {
+  "id": "3a1d337255c7e207",
+  "type": "json",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "",
+  "property": "payload",
+  "action": "",
+  "pretty": false,
+  "x": 1010,
+  "y": 60,
+  "wires": [
+    [
+      "0f9cc8245b0bfdac"
+    ]
+  ],
+  "_order": 229
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.4ef6f0b5052e89da.flows.js
+++ b/node-red/flows_js/json.4ef6f0b5052e89da.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "a1025e65d5b222fa"
     ]
   ],
-  "_order": 168
+  "_order": 187
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.5146e3cffcd5989c.flows.js
+++ b/node-red/flows_js/json.5146e3cffcd5989c.flows.js
@@ -13,7 +13,7 @@ const Node = {
       "bf76db2ac198b50b"
     ]
   ],
-  "_order": 136
+  "_order": 155
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.6599492760ca4710.flows.js
+++ b/node-red/flows_js/json.6599492760ca4710.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "6599492760ca4710",
+  "type": "json",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "",
+  "property": "payload",
+  "action": "",
+  "pretty": false,
+  "x": 970,
+  "y": 500,
+  "wires": [
+    []
+  ],
+  "_order": 335
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.758b1a3ab736cae5.flows.js
+++ b/node-red/flows_js/json.758b1a3ab736cae5.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 154
+  "_order": 173
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.90d08a0b2cd1e598.flows.js
+++ b/node-red/flows_js/json.90d08a0b2cd1e598.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 142
+  "_order": 161
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.a1043807c29f2e48.flows.js
+++ b/node-red/flows_js/json.a1043807c29f2e48.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 109
+  "_order": 128
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.a87301fa2a0d3ad8.flows.js
+++ b/node-red/flows_js/json.a87301fa2a0d3ad8.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "a87301fa2a0d3ad8",
+  "type": "json",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "",
+  "property": "data",
+  "action": "obj",
+  "pretty": false,
+  "x": 1090,
+  "y": 420,
+  "wires": [
+    []
+  ],
+  "_order": 215
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.b7fbaea9143be3f1.flows.js
+++ b/node-red/flows_js/json.b7fbaea9143be3f1.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 104
+  "_order": 123
 }
 
 module.exports = Node;

--- a/node-red/flows_js/json.c79147f32272c1d1.flows.js
+++ b/node-red/flows_js/json.c79147f32272c1d1.flows.js
@@ -1,0 +1,19 @@
+const Node = {
+  "id": "c79147f32272c1d1",
+  "type": "json",
+  "z": "80076417ef9f662a",
+  "name": "",
+  "property": "payload",
+  "action": "",
+  "pretty": false,
+  "x": 590,
+  "y": 200,
+  "wires": [
+    [
+      "6ee1013da7bc9311"
+    ]
+  ],
+  "_order": 197
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.dc172905d7889d81.flows.js
+++ b/node-red/flows_js/json.dc172905d7889d81.flows.js
@@ -1,0 +1,20 @@
+const Node = {
+  "id": "dc172905d7889d81",
+  "type": "json",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "",
+  "property": "payload",
+  "action": "",
+  "pretty": false,
+  "x": 1070,
+  "y": 120,
+  "wires": [
+    [
+      "ada1085ad5696009"
+    ]
+  ],
+  "_order": 224
+}
+
+module.exports = Node;

--- a/node-red/flows_js/json.dd950470079df58a.flows.js
+++ b/node-red/flows_js/json.dd950470079df58a.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "dd950470079df58a",
+  "type": "json",
+  "z": "16bb519c7f773542",
+  "g": "7a6becc707d70bf4",
+  "name": "",
+  "property": "payload",
+  "action": "obj",
+  "pretty": false,
+  "x": 710,
+  "y": 100,
+  "wires": [
+    []
+  ],
+  "_order": 203
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.02c42f1bea2e8afc.flows.js
+++ b/node-red/flows_js/junction.02c42f1bea2e8afc.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "522e1207706ea814"
     ]
   ],
-  "_order": 55
+  "_order": 64
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.0d4bd6b6b499d69b.flows.js
+++ b/node-red/flows_js/junction.0d4bd6b6b499d69b.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "0d4bd6b6b499d69b",
+  "type": "junction",
+  "z": "452aaf8dc5cd8d45",
+  "x": 40,
+  "y": 360,
+  "wires": [
+    [
+      "f4bd6b60fe46c7ee"
+    ]
+  ],
+  "_order": 115
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.0f58b58f8df7f5e7.flows.js
+++ b/node-red/flows_js/junction.0f58b58f8df7f5e7.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "1817ef0c011528f5"
     ]
   ],
-  "_order": 81
+  "_order": 90
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.12af887fa3e97f37.flows.js
+++ b/node-red/flows_js/junction.12af887fa3e97f37.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "b747aa1f23624263"
     ]
   ],
-  "_order": 71
+  "_order": 80
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.1e60431a130cdd16.flows.js
+++ b/node-red/flows_js/junction.1e60431a130cdd16.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "aad8b87994f0fc75"
     ]
   ],
-  "_order": 83
+  "_order": 92
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.1f2e5cdec5771807.flows.js
+++ b/node-red/flows_js/junction.1f2e5cdec5771807.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "c7afbc2c2d304e32"
     ]
   ],
-  "_order": 85
+  "_order": 94
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.28f5a6dc5f375384.flows.js
+++ b/node-red/flows_js/junction.28f5a6dc5f375384.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "46868fe38cf5a184"
     ]
   ],
-  "_order": 53
+  "_order": 62
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.351286a4aae46341.flows.js
+++ b/node-red/flows_js/junction.351286a4aae46341.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "81f13c91b55d0c5d"
     ]
   ],
-  "_order": 91
+  "_order": 100
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.3acaac41151b641f.flows.js
+++ b/node-red/flows_js/junction.3acaac41151b641f.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "3acaac41151b641f",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 1380,
+  "y": 200,
+  "wires": [
+    [
+      "d8c9a5bec44058fd"
+    ]
+  ],
+  "_order": 110
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.3af44629275ce741.flows.js
+++ b/node-red/flows_js/junction.3af44629275ce741.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "85b6b60428bd1e4c"
     ]
   ],
-  "_order": 74
+  "_order": 83
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.3fcc4bd01ebeb3cf.flows.js
+++ b/node-red/flows_js/junction.3fcc4bd01ebeb3cf.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "5146e3cffcd5989c"
     ]
   ],
-  "_order": 88
+  "_order": 97
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.440fe5b20f5ad96e.flows.js
+++ b/node-red/flows_js/junction.440fe5b20f5ad96e.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "df402f850c9187c4"
     ]
   ],
-  "_order": 87
+  "_order": 96
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.45577688ac957f99.flows.js
+++ b/node-red/flows_js/junction.45577688ac957f99.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "6ce841fbce39163d"
     ]
   ],
-  "_order": 77
+  "_order": 86
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.4b86f589fd76f9d5.flows.js
+++ b/node-red/flows_js/junction.4b86f589fd76f9d5.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "0e0f9df272dc5fc1"
     ]
   ],
-  "_order": 63
+  "_order": 72
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.5144e4be8fd69dbf.flows.js
+++ b/node-red/flows_js/junction.5144e4be8fd69dbf.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "5677ad908821d1ec"
     ]
   ],
-  "_order": 46
+  "_order": 55
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.522e1207706ea814.flows.js
+++ b/node-red/flows_js/junction.522e1207706ea814.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "90b5f43d586b5bfe"
     ]
   ],
-  "_order": 54
+  "_order": 63
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.5677ad908821d1ec.flows.js
+++ b/node-red/flows_js/junction.5677ad908821d1ec.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "6440c7c789cb52fe"
     ]
   ],
-  "_order": 45
+  "_order": 54
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.67293dd84e1b0b5c.flows.js
+++ b/node-red/flows_js/junction.67293dd84e1b0b5c.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "9b3dab7dd179293a"
     ]
   ],
-  "_order": 64
+  "_order": 73
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.698ef7d845c45259.flows.js
+++ b/node-red/flows_js/junction.698ef7d845c45259.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "fb7d930fcfb35801"
     ]
   ],
-  "_order": 69
+  "_order": 78
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.6a2a56ca0f18b384.flows.js
+++ b/node-red/flows_js/junction.6a2a56ca0f18b384.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "67293dd84e1b0b5c"
     ]
   ],
-  "_order": 67
+  "_order": 76
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.73774a24e7a533ac.flows.js
+++ b/node-red/flows_js/junction.73774a24e7a533ac.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "882797cfacc7ff7c"
     ]
   ],
-  "_order": 59
+  "_order": 68
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.760ecf35e1a9bc7a.flows.js
+++ b/node-red/flows_js/junction.760ecf35e1a9bc7a.flows.js
@@ -1,0 +1,16 @@
+const Node = {
+  "id": "760ecf35e1a9bc7a",
+  "type": "junction",
+  "z": "80076417ef9f662a",
+  "x": 540,
+  "y": 100,
+  "wires": [
+    [
+      "34dd072b36b86418",
+      "c79147f32272c1d1"
+    ]
+  ],
+  "_order": 107
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.763d8eba5c8a6e8f.flows.js
+++ b/node-red/flows_js/junction.763d8eba5c8a6e8f.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "28f5a6dc5f375384"
     ]
   ],
-  "_order": 72
+  "_order": 81
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.7759da22b51a03e5.flows.js
+++ b/node-red/flows_js/junction.7759da22b51a03e5.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "3302debcb6e0a7d8"
     ]
   ],
-  "_order": 58
+  "_order": 67
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.81f13c91b55d0c5d.flows.js
+++ b/node-red/flows_js/junction.81f13c91b55d0c5d.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "15f36b2bf598cbab"
     ]
   ],
-  "_order": 92
+  "_order": 101
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.8604a55da5a084e7.flows.js
+++ b/node-red/flows_js/junction.8604a55da5a084e7.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "b0548528e2651ef3"
     ]
   ],
-  "_order": 95
+  "_order": 104
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.868f02785483d3db.flows.js
+++ b/node-red/flows_js/junction.868f02785483d3db.flows.js
@@ -1,0 +1,13 @@
+const Node = {
+  "id": "868f02785483d3db",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 1880,
+  "y": 360,
+  "wires": [
+    []
+  ],
+  "_order": 109
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.88134273a1fcabf6.flows.js
+++ b/node-red/flows_js/junction.88134273a1fcabf6.flows.js
@@ -7,7 +7,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 89
+  "_order": 98
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.8ad4b29a3e40eee8.flows.js
+++ b/node-red/flows_js/junction.8ad4b29a3e40eee8.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "cc9b98b49a6db610"
     ]
   ],
-  "_order": 56
+  "_order": 65
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.8da9a91194f7af91.flows.js
+++ b/node-red/flows_js/junction.8da9a91194f7af91.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "85f69593f6d7665e"
     ]
   ],
-  "_order": 65
+  "_order": 74
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.9f26056c146514b7.flows.js
+++ b/node-red/flows_js/junction.9f26056c146514b7.flows.js
@@ -1,0 +1,13 @@
+const Node = {
+  "id": "9f26056c146514b7",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 60,
+  "y": 380,
+  "wires": [
+    []
+  ],
+  "_order": 112
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.a02c4fae11dcffba.flows.js
+++ b/node-red/flows_js/junction.a02c4fae11dcffba.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "65e7437a46c33c4d"
     ]
   ],
-  "_order": 51
+  "_order": 60
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.a2685221cb05fc5a.flows.js
+++ b/node-red/flows_js/junction.a2685221cb05fc5a.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "8625b2fab96ba8e9"
     ]
   ],
-  "_order": 62
+  "_order": 71
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.a45baa0bfa1b3f64.flows.js
+++ b/node-red/flows_js/junction.a45baa0bfa1b3f64.flows.js
@@ -7,7 +7,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 80
+  "_order": 89
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.ac5e094c99a67b2d.flows.js
+++ b/node-red/flows_js/junction.ac5e094c99a67b2d.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "8f35b8f426ac7542"
     ]
   ],
-  "_order": 79
+  "_order": 88
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.b0548528e2651ef3.flows.js
+++ b/node-red/flows_js/junction.b0548528e2651ef3.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "f0f28151b9339fac"
     ]
   ],
-  "_order": 94
+  "_order": 103
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.bd0b03ef988fc0fe.flows.js
+++ b/node-red/flows_js/junction.bd0b03ef988fc0fe.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "a1b312bc38e81c73"
     ]
   ],
-  "_order": 97
+  "_order": 106
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.bd2b9952cd356fa4.flows.js
+++ b/node-red/flows_js/junction.bd2b9952cd356fa4.flows.js
@@ -7,7 +7,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 90
+  "_order": 99
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.bef728771c500c07.flows.js
+++ b/node-red/flows_js/junction.bef728771c500c07.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "73774a24e7a533ac"
     ]
   ],
-  "_order": 60
+  "_order": 69
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.c606d977ccc17344.flows.js
+++ b/node-red/flows_js/junction.c606d977ccc17344.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "fcaad244b4f1f00c"
     ]
   ],
-  "_order": 47
+  "_order": 56
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.c680fc2ebd378756.flows.js
+++ b/node-red/flows_js/junction.c680fc2ebd378756.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "bd0b03ef988fc0fe"
     ]
   ],
-  "_order": 96
+  "_order": 105
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.cc489fac9fece954.flows.js
+++ b/node-red/flows_js/junction.cc489fac9fece954.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "cabaa0127db8b20a"
     ]
   ],
-  "_order": 68
+  "_order": 77
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.cc9b98b49a6db610.flows.js
+++ b/node-red/flows_js/junction.cc9b98b49a6db610.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "daa7a7e364322fd6"
     ]
   ],
-  "_order": 52
+  "_order": 61
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.cd287725f072abe7.flows.js
+++ b/node-red/flows_js/junction.cd287725f072abe7.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "1e60431a130cdd16"
     ]
   ],
-  "_order": 82
+  "_order": 91
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.cd2e6087b8df1d90.flows.js
+++ b/node-red/flows_js/junction.cd2e6087b8df1d90.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "cd2e6087b8df1d90",
+  "type": "junction",
+  "z": "452aaf8dc5cd8d45",
+  "x": 1280,
+  "y": 320,
+  "wires": [
+    [
+      "0d4bd6b6b499d69b"
+    ]
+  ],
+  "_order": 116
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.cf67a8d63c246c46.flows.js
+++ b/node-red/flows_js/junction.cf67a8d63c246c46.flows.js
@@ -7,7 +7,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 93
+  "_order": 102
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.d7aaefeaee85fde1.flows.js
+++ b/node-red/flows_js/junction.d7aaefeaee85fde1.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "d7aaefeaee85fde1",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 60,
+  "y": 380,
+  "wires": [
+    [
+      "b91ac275b4e70f51"
+    ]
+  ],
+  "_order": 113
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.d8c9a5bec44058fd.flows.js
+++ b/node-red/flows_js/junction.d8c9a5bec44058fd.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "d8c9a5bec44058fd",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 60,
+  "y": 240,
+  "wires": [
+    [
+      "503e7c1fc3fe9500"
+    ]
+  ],
+  "_order": 111
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.dd87d22120b64e28.flows.js
+++ b/node-red/flows_js/junction.dd87d22120b64e28.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "2e9339b2c18a23f4"
     ]
   ],
-  "_order": 57
+  "_order": 66
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.df402f850c9187c4.flows.js
+++ b/node-red/flows_js/junction.df402f850c9187c4.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "c7afbc2c2d304e32"
     ]
   ],
-  "_order": 86
+  "_order": 95
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.e330064ce7a79cc8.flows.js
+++ b/node-red/flows_js/junction.e330064ce7a79cc8.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "a02c4fae11dcffba"
     ]
   ],
-  "_order": 50
+  "_order": 59
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.e5d65cb5d9556f7b.flows.js
+++ b/node-red/flows_js/junction.e5d65cb5d9556f7b.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "f2715c7e9e262cd3"
     ]
   ],
-  "_order": 76
+  "_order": 85
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.ead0a5539c5bb1b9.flows.js
+++ b/node-red/flows_js/junction.ead0a5539c5bb1b9.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "77b93de03ab58823"
     ]
   ],
-  "_order": 49
+  "_order": 58
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.ec2cbaa5abdb2dc0.flows.js
+++ b/node-red/flows_js/junction.ec2cbaa5abdb2dc0.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "cc489fac9fece954"
     ]
   ],
-  "_order": 78
+  "_order": 87
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.eca4a640b3925439.flows.js
+++ b/node-red/flows_js/junction.eca4a640b3925439.flows.js
@@ -10,7 +10,7 @@ const Node = {
       "c2a7d80a8df9fc53"
     ]
   ],
-  "_order": 73
+  "_order": 82
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.eca82ec062fb212f.flows.js
+++ b/node-red/flows_js/junction.eca82ec062fb212f.flows.js
@@ -1,0 +1,13 @@
+const Node = {
+  "id": "eca82ec062fb212f",
+  "type": "junction",
+  "z": "80076417ef9f662a",
+  "x": 760,
+  "y": 200,
+  "wires": [
+    []
+  ],
+  "_order": 108
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.ee650a883692de95.flows.js
+++ b/node-red/flows_js/junction.ee650a883692de95.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "dd87d22120b64e28"
     ]
   ],
-  "_order": 61
+  "_order": 70
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.f2715c7e9e262cd3.flows.js
+++ b/node-red/flows_js/junction.f2715c7e9e262cd3.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "74d1dfee25742878"
     ]
   ],
-  "_order": 48
+  "_order": 57
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.f332853c388a1c3d.flows.js
+++ b/node-red/flows_js/junction.f332853c388a1c3d.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "7759da22b51a03e5"
     ]
   ],
-  "_order": 75
+  "_order": 84
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.f998e08a71c1f45e.flows.js
+++ b/node-red/flows_js/junction.f998e08a71c1f45e.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "f998e08a71c1f45e",
+  "type": "junction",
+  "z": "6b360b454d19172a",
+  "x": 600,
+  "y": 340,
+  "wires": [
+    [
+      "d7aaefeaee85fde1"
+    ]
+  ],
+  "_order": 114
+}
+
+module.exports = Node;

--- a/node-red/flows_js/junction.fa939abeb90991a5.flows.js
+++ b/node-red/flows_js/junction.fa939abeb90991a5.flows.js
@@ -7,7 +7,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 84
+  "_order": 93
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.fb7d930fcfb35801.flows.js
+++ b/node-red/flows_js/junction.fb7d930fcfb35801.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "1ae4294ce24de36c"
     ]
   ],
-  "_order": 70
+  "_order": 79
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.fc9b6e0147d4efe1.flows.js
+++ b/node-red/flows_js/junction.fc9b6e0147d4efe1.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "8da9a91194f7af91"
     ]
   ],
-  "_order": 66
+  "_order": 75
 }
 
 module.exports = Node;

--- a/node-red/flows_js/junction.fcaad244b4f1f00c.flows.js
+++ b/node-red/flows_js/junction.fcaad244b4f1f00c.flows.js
@@ -9,7 +9,7 @@ const Node = {
       "1a4e1900ef39aeb2"
     ]
   ],
-  "_order": 44
+  "_order": 53
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_in.66420c5109c50919.flows.js
+++ b/node-red/flows_js/link_in.66420c5109c50919.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 150
+  "_order": 169
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_in.91e50ea2bc982f31.flows.js
+++ b/node-red/flows_js/link_in.91e50ea2bc982f31.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "91e50ea2bc982f31",
+  "type": "link in",
+  "z": "6b360b454d19172a",
+  "name": "retry",
+  "links": [
+    "d724de646703fe6a",
+    "1edfd2ca9d9adb45"
+  ],
+  "x": 1225,
+  "y": 520,
+  "wires": [
+    []
+  ],
+  "_order": 211
+}
+
+module.exports = Node;

--- a/node-red/flows_js/link_in.a7033b97c1fb77e2.flows.js
+++ b/node-red/flows_js/link_in.a7033b97c1fb77e2.flows.js
@@ -15,7 +15,7 @@ const Node = {
       "c1638c1915bee2ca"
     ]
   ],
-  "_order": 269
+  "_order": 330
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_out.1edfd2ca9d9adb45.flows.js
+++ b/node-red/flows_js/link_out.1edfd2ca9d9adb45.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "1edfd2ca9d9adb45",
+  "type": "link out",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Schedule a retry",
+  "mode": "link",
+  "links": [
+    "91e50ea2bc982f31"
+  ],
+  "x": 1100,
+  "y": 180,
+  "wires": [],
+  "l": true,
+  "_order": 226
+}
+
+module.exports = Node;

--- a/node-red/flows_js/link_out.2acfab588074f57d.flows.js
+++ b/node-red/flows_js/link_out.2acfab588074f57d.flows.js
@@ -11,7 +11,7 @@ const Node = {
   "x": 375,
   "y": 80,
   "wires": [],
-  "_order": 268
+  "_order": 329
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_out.3b17098a02d1b641.flows.js
+++ b/node-red/flows_js/link_out.3b17098a02d1b641.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "y": 480,
   "wires": [],
   "l": true,
-  "_order": 158
+  "_order": 177
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_out.ae1a820ef89ab3a6.flows.js
+++ b/node-red/flows_js/link_out.ae1a820ef89ab3a6.flows.js
@@ -12,7 +12,7 @@ const Node = {
   "y": 180,
   "wires": [],
   "l": true,
-  "_order": 165
+  "_order": 184
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_out.b0249616c8f8c2fb.flows.js
+++ b/node-red/flows_js/link_out.b0249616c8f8c2fb.flows.js
@@ -11,7 +11,7 @@ const Node = {
   "x": 1175,
   "y": 260,
   "wires": [],
-  "_order": 261
+  "_order": 322
 }
 
 module.exports = Node;

--- a/node-red/flows_js/link_out.d724de646703fe6a.flows.js
+++ b/node-red/flows_js/link_out.d724de646703fe6a.flows.js
@@ -1,0 +1,18 @@
+const Node = {
+  "id": "d724de646703fe6a",
+  "type": "link out",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "Schedule a retry",
+  "mode": "link",
+  "links": [
+    "91e50ea2bc982f31"
+  ],
+  "x": 880,
+  "y": 480,
+  "wires": [],
+  "l": true,
+  "_order": 219
+}
+
+module.exports = Node;

--- a/node-red/flows_js/mysql_connector.92e3a81fda5638eb.flows.js
+++ b/node-red/flows_js/mysql_connector.92e3a81fda5638eb.flows.js
@@ -13,7 +13,7 @@ const Node = {
       "d5885d75e53926eb"
     ]
   ],
-  "_order": 138
+  "_order": 157
 }
 
 module.exports = Node;

--- a/node-red/flows_js/mysql_connector.aee5892dbbe3d82b.flows.js
+++ b/node-red/flows_js/mysql_connector.aee5892dbbe3d82b.flows.js
@@ -13,7 +13,7 @@ const Node = {
       "5da16564b7f0f0c1"
     ]
   ],
-  "_order": 100
+  "_order": 119
 }
 
 module.exports = Node;

--- a/node-red/flows_js/mysql_connector.afac8653d4fb392b.flows.js
+++ b/node-red/flows_js/mysql_connector.afac8653d4fb392b.flows.js
@@ -1,0 +1,19 @@
+const Node = {
+  "id": "afac8653d4fb392b",
+  "type": "MySQL-Connector",
+  "z": "16bb519c7f773542",
+  "g": "7a6becc707d70bf4",
+  "server": "8dd94efcd0784de3",
+  "name": "Send forespørgsel",
+  "x": 310,
+  "y": 100,
+  "wires": [
+    [
+      "2d2c9c09066d17ba",
+      "b8d31274717de389"
+    ]
+  ],
+  "_order": 199
+}
+
+module.exports = Node;

--- a/node-red/flows_js/mysql_server_connector.8dd94efcd0784de3.flows.js
+++ b/node-red/flows_js/mysql_server_connector.8dd94efcd0784de3.flows.js
@@ -8,7 +8,7 @@ const Node = {
   "password": "${DB_PASS}",
   "tls": false,
   "database": "${DB_DATABASE}",
-  "_order": 99
+  "_order": 118
 }
 
 module.exports = Node;

--- a/node-red/flows_js/split.15f36b2bf598cbab.flows.js
+++ b/node-red/flows_js/split.15f36b2bf598cbab.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "b242a32b92dc5512"
     ]
   ],
-  "_order": 145
+  "_order": 164
 }
 
 module.exports = Node;

--- a/node-red/flows_js/split.1a4e1900ef39aeb2.flows.js
+++ b/node-red/flows_js/split.1a4e1900ef39aeb2.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "9e80d7b912c64137"
     ]
   ],
-  "_order": 219
+  "_order": 280
 }
 
 module.exports = Node;

--- a/node-red/flows_js/split.503e7c1fc3fe9500.flows.js
+++ b/node-red/flows_js/split.503e7c1fc3fe9500.flows.js
@@ -1,0 +1,23 @@
+const Node = {
+  "id": "503e7c1fc3fe9500",
+  "type": "split",
+  "z": "6b360b454d19172a",
+  "g": "4d967bbe9d19abb4",
+  "name": "",
+  "splt": "\\n",
+  "spltType": "str",
+  "arraySplt": 1,
+  "arraySpltType": "len",
+  "stream": false,
+  "addname": "",
+  "x": 190,
+  "y": 300,
+  "wires": [
+    [
+      "b569417d9c845b0f"
+    ]
+  ],
+  "_order": 206
+}
+
+module.exports = Node;

--- a/node-red/flows_js/split.9b3dab7dd179293a.flows.js
+++ b/node-red/flows_js/split.9b3dab7dd179293a.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "bae7dd126b39e4a3"
     ]
   ],
-  "_order": 244
+  "_order": 305
 }
 
 module.exports = Node;

--- a/node-red/flows_js/split.aad8b87994f0fc75.flows.js
+++ b/node-red/flows_js/split.aad8b87994f0fc75.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "5084542eca312ff6"
     ]
   ],
-  "_order": 119
+  "_order": 138
 }
 
 module.exports = Node;

--- a/node-red/flows_js/status.0edb927b549dc4ac.flows.js
+++ b/node-red/flows_js/status.0edb927b549dc4ac.flows.js
@@ -9,7 +9,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 105
+  "_order": 124
 }
 
 module.exports = Node;

--- a/node-red/flows_js/status.4a203e88953638b2.flows.js
+++ b/node-red/flows_js/status.4a203e88953638b2.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "4a203e88953638b2",
+  "type": "status",
+  "z": "80076417ef9f662a",
+  "name": "",
+  "scope": null,
+  "x": 1240,
+  "y": 280,
+  "wires": [
+    []
+  ],
+  "_order": 198
+}
+
+module.exports = Node;

--- a/node-red/flows_js/status.6f8344677b6e0547.flows.js
+++ b/node-red/flows_js/status.6f8344677b6e0547.flows.js
@@ -9,7 +9,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 137
+  "_order": 156
 }
 
 module.exports = Node;

--- a/node-red/flows_js/status.c1ce98d04720ba49.flows.js
+++ b/node-red/flows_js/status.c1ce98d04720ba49.flows.js
@@ -9,7 +9,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 143
+  "_order": 162
 }
 
 module.exports = Node;

--- a/node-red/flows_js/status.df0bf16430a72b92.flows.js
+++ b/node-red/flows_js/status.df0bf16430a72b92.flows.js
@@ -1,0 +1,15 @@
+const Node = {
+  "id": "df0bf16430a72b92",
+  "type": "status",
+  "z": "6b360b454d19172a",
+  "name": "",
+  "scope": null,
+  "x": 1220,
+  "y": 600,
+  "wires": [
+    []
+  ],
+  "_order": 204
+}
+
+module.exports = Node;

--- a/node-red/flows_js/subflow.16bb519c7f773542.flows.js
+++ b/node-red/flows_js/subflow.16bb519c7f773542.flows.js
@@ -1,0 +1,43 @@
+const Node = {
+  "id": "16bb519c7f773542",
+  "type": "subflow",
+  "name": "Database connector (3)",
+  "info": "",
+  "category": "",
+  "in": [
+    {
+      "x": 80,
+      "y": 100,
+      "wires": [
+        {
+          "id": "afac8653d4fb392b"
+        }
+      ]
+    }
+  ],
+  "out": [
+    {
+      "x": 930,
+      "y": 100,
+      "wires": [
+        {
+          "id": "dd950470079df58a",
+          "port": 0
+        }
+      ]
+    }
+  ],
+  "env": [],
+  "meta": {},
+  "color": "#3FADB5",
+  "inputLabels": [
+    "Query input"
+  ],
+  "outputLabels": [
+    "Result output"
+  ],
+  "icon": "node-red/db.svg",
+  "_order": 11
+}
+
+module.exports = Node;

--- a/node-red/flows_js/subflow.6b360b454d19172a.flows.js
+++ b/node-red/flows_js/subflow.6b360b454d19172a.flows.js
@@ -1,0 +1,76 @@
+const Node = {
+  "id": "6b360b454d19172a",
+  "type": "subflow",
+  "name": "OpenData.dk - Randers org. - Connector (3)",
+  "info": "",
+  "category": "",
+  "in": [
+    {
+      "x": 40,
+      "y": 40,
+      "wires": [
+        {
+          "id": "c9ceb3f69f2e739e"
+        }
+      ]
+    }
+  ],
+  "out": [
+    {
+      "x": 1320,
+      "y": 320,
+      "wires": [
+        {
+          "id": "2e39b79d2576f9ba",
+          "port": 0
+        },
+        {
+          "id": "bb89ca1a3f3c4750",
+          "port": 0
+        }
+      ]
+    },
+    {
+      "x": 1310,
+      "y": 420,
+      "wires": [
+        {
+          "id": "a87301fa2a0d3ad8",
+          "port": 0
+        }
+      ]
+    },
+    {
+      "x": 1310,
+      "y": 520,
+      "wires": [
+        {
+          "id": "91e50ea2bc982f31",
+          "port": 0
+        }
+      ]
+    }
+  ],
+  "env": [],
+  "meta": {},
+  "color": "#E9967A",
+  "outputLabels": [
+    "metrics",
+    "data",
+    "retry"
+  ],
+  "icon": "node-red/inject.svg",
+  "status": {
+    "x": 1340,
+    "y": 600,
+    "wires": [
+      {
+        "id": "df0bf16430a72b92",
+        "port": 0
+      }
+    ]
+  },
+  "_order": 12
+}
+
+module.exports = Node;

--- a/node-red/flows_js/subflow.80076417ef9f662a.flows.js
+++ b/node-red/flows_js/subflow.80076417ef9f662a.flows.js
@@ -1,0 +1,56 @@
+const Node = {
+  "id": "80076417ef9f662a",
+  "type": "subflow",
+  "name": "Schedule Retry (2)",
+  "info": "",
+  "category": "",
+  "in": [
+    {
+      "x": 60,
+      "y": 100,
+      "wires": [
+        {
+          "id": "fdd8f9690b8a671b"
+        }
+      ]
+    }
+  ],
+  "out": [
+    {
+      "x": 1400,
+      "y": 120,
+      "wires": [
+        {
+          "id": "79d8b2a874c4987a",
+          "port": 0
+        }
+      ]
+    },
+    {
+      "x": 1400,
+      "y": 200,
+      "wires": [
+        {
+          "id": "eca82ec062fb212f",
+          "port": 0
+        }
+      ]
+    }
+  ],
+  "env": [],
+  "meta": {},
+  "color": "#DDAA99",
+  "status": {
+    "x": 1400,
+    "y": 280,
+    "wires": [
+      {
+        "id": "4a203e88953638b2",
+        "port": 0
+      }
+    ]
+  },
+  "_order": 10
+}
+
+module.exports = Node;

--- a/node-red/flows_js/subflow_16bb519c7f773542.1adb98814879c48c.flows.js
+++ b/node-red/flows_js/subflow_16bb519c7f773542.1adb98814879c48c.flows.js
@@ -1,0 +1,17 @@
+const Node = {
+  "id": "1adb98814879c48c",
+  "type": "subflow:16bb519c7f773542",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "",
+  "x": 770,
+  "y": 500,
+  "wires": [
+    [
+      "6599492760ca4710"
+    ]
+  ],
+  "_order": 336
+}
+
+module.exports = Node;

--- a/node-red/flows_js/subflow_5ee0ae05e3ad5b5a.3103a50c2f18e075.flows.js
+++ b/node-red/flows_js/subflow_5ee0ae05e3ad5b5a.3103a50c2f18e075.flows.js
@@ -14,7 +14,7 @@ const Node = {
       "64725cf513a36044"
     ]
   ],
-  "_order": 262
+  "_order": 323
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.1684e0f47b1b54d1.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.1684e0f47b1b54d1.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "8517e1ef1f306cd4"
     ]
   ],
-  "_order": 209
+  "_order": 270
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.43d0cf92514303e7.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.43d0cf92514303e7.flows.js
@@ -12,7 +12,7 @@ const Node = {
       "e5d65cb5d9556f7b"
     ]
   ],
-  "_order": 225
+  "_order": 286
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.4be122699e16f822.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.4be122699e16f822.flows.js
@@ -12,7 +12,7 @@ const Node = {
       "ec2cbaa5abdb2dc0"
     ]
   ],
-  "_order": 250
+  "_order": 311
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.7f3fa659dc7e3a5c.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.7f3fa659dc7e3a5c.flows.js
@@ -12,7 +12,7 @@ const Node = {
       "763d8eba5c8a6e8f"
     ]
   ],
-  "_order": 208
+  "_order": 269
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.8325eda0730fbb71.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.8325eda0730fbb71.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "69dbd2a0eb7ccecd"
     ]
   ],
-  "_order": 232
+  "_order": 293
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.8899c8d86911d51f.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.8899c8d86911d51f.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "4cfca818d34a77d6"
     ]
   ],
-  "_order": 254
+  "_order": 315
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.921fba1309b4cc59.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.921fba1309b4cc59.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "3dbcb455c679d5cd"
     ]
   ],
-  "_order": 231
+  "_order": 292
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.b066f894d60d04da.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.b066f894d60d04da.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "9eb71b7a3795cc96"
     ]
   ],
-  "_order": 188
+  "_order": 249
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.b876a7ae4aa0d502.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.b876a7ae4aa0d502.flows.js
@@ -11,7 +11,7 @@ const Node = {
       "273cf4f3b5ad8b9d"
     ]
   ],
-  "_order": 255
+  "_order": 316
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_5f815c7f5707ec58.f4071b3393682d2e.flows.js
+++ b/node-red/flows_js/subflow_5f815c7f5707ec58.f4071b3393682d2e.flows.js
@@ -12,7 +12,7 @@ const Node = {
       "f332853c388a1c3d"
     ]
   ],
-  "_order": 184
+  "_order": 245
 }
 
 module.exports = Node;

--- a/node-red/flows_js/subflow_f15ef1d8b0c08ad3.6a5e831da5abdd74.flows.js
+++ b/node-red/flows_js/subflow_f15ef1d8b0c08ad3.6a5e831da5abdd74.flows.js
@@ -18,7 +18,7 @@ const Node = {
     ]
   ],
   "info": "",
-  "_order": 259
+  "_order": 320
 }
 
 Node.info = `

--- a/node-red/flows_js/switch.22ee05fb2aa11f3b.flows.js
+++ b/node-red/flows_js/switch.22ee05fb2aa11f3b.flows.js
@@ -29,7 +29,7 @@ const Node = {
       "e5361e70221c8772"
     ]
   ],
-  "_order": 112
+  "_order": 131
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.310f915d8edfc229.flows.js
+++ b/node-red/flows_js/switch.310f915d8edfc229.flows.js
@@ -28,7 +28,7 @@ const Node = {
       "88134273a1fcabf6"
     ]
   ],
-  "_order": 133
+  "_order": 152
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.34dd072b36b86418.flows.js
+++ b/node-red/flows_js/switch.34dd072b36b86418.flows.js
@@ -1,0 +1,34 @@
+const Node = {
+  "id": "34dd072b36b86418",
+  "type": "switch",
+  "z": "80076417ef9f662a",
+  "name": "",
+  "property": "config.currentRetryAttempt",
+  "propertyType": "msg",
+  "rules": [
+    {
+      "t": "else"
+    },
+    {
+      "t": "lte",
+      "v": "config.retryAttempts",
+      "vt": "str"
+    }
+  ],
+  "checkall": "true",
+  "repair": false,
+  "outputs": 2,
+  "x": 630,
+  "y": 100,
+  "wires": [
+    [
+      "487ad510ea1fe3e0"
+    ],
+    [
+      "eca82ec062fb212f"
+    ]
+  ],
+  "_order": 194
+}
+
+module.exports = Node;

--- a/node-red/flows_js/switch.3dbcb455c679d5cd.flows.js
+++ b/node-red/flows_js/switch.3dbcb455c679d5cd.flows.js
@@ -27,7 +27,7 @@ const Node = {
       "72ee09fd25a880d5"
     ]
   ],
-  "_order": 212
+  "_order": 273
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.4370572af6e58e63.flows.js
+++ b/node-red/flows_js/switch.4370572af6e58e63.flows.js
@@ -28,7 +28,7 @@ const Node = {
       "3d995f447af30ece"
     ]
   ],
-  "_order": 128
+  "_order": 147
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.4cfca818d34a77d6.flows.js
+++ b/node-red/flows_js/switch.4cfca818d34a77d6.flows.js
@@ -27,7 +27,7 @@ const Node = {
       "627b9982c16502f9"
     ]
   ],
-  "_order": 237
+  "_order": 298
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.5084542eca312ff6.flows.js
+++ b/node-red/flows_js/switch.5084542eca312ff6.flows.js
@@ -34,7 +34,7 @@ const Node = {
     "created today",
     ""
   ],
-  "_order": 111
+  "_order": 130
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.59b47841deed3db1.flows.js
+++ b/node-red/flows_js/switch.59b47841deed3db1.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "8f35b8f426ac7542"
     ]
   ],
-  "_order": 253
+  "_order": 314
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.7278d8a019646c2b.flows.js
+++ b/node-red/flows_js/switch.7278d8a019646c2b.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "85b6b60428bd1e4c"
     ]
   ],
-  "_order": 187
+  "_order": 248
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.7a9038c6f798cfa3.flows.js
+++ b/node-red/flows_js/switch.7a9038c6f798cfa3.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "c2a7d80a8df9fc53"
     ]
   ],
-  "_order": 207
+  "_order": 268
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.7e95b253cad342a4.flows.js
+++ b/node-red/flows_js/switch.7e95b253cad342a4.flows.js
@@ -23,7 +23,7 @@ const Node = {
       "6ce841fbce39163d"
     ]
   ],
-  "_order": 228
+  "_order": 289
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.8a5ff7ce2b284e37.flows.js
+++ b/node-red/flows_js/switch.8a5ff7ce2b284e37.flows.js
@@ -29,7 +29,7 @@ const Node = {
       "ae1a820ef89ab3a6"
     ]
   ],
-  "_order": 162
+  "_order": 181
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.9ebe4442caf07207.flows.js
+++ b/node-red/flows_js/switch.9ebe4442caf07207.flows.js
@@ -29,7 +29,7 @@ const Node = {
       "3b17098a02d1b641"
     ]
   ],
-  "_order": 156
+  "_order": 175
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.b242a32b92dc5512.flows.js
+++ b/node-red/flows_js/switch.b242a32b92dc5512.flows.js
@@ -34,7 +34,7 @@ const Node = {
     "created today",
     ""
   ],
-  "_order": 144
+  "_order": 163
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.b569417d9c845b0f.flows.js
+++ b/node-red/flows_js/switch.b569417d9c845b0f.flows.js
@@ -1,0 +1,40 @@
+const Node = {
+  "id": "b569417d9c845b0f",
+  "type": "switch",
+  "z": "6b360b454d19172a",
+  "g": "4d967bbe9d19abb4",
+  "name": "Datafilter ↓ udvælg filer oprettet \\n  for max_file_age_days siden",
+  "property": "payload.created ~> $substring(0,10)",
+  "propertyType": "jsonata",
+  "rules": [
+    {
+      "t": "gte",
+      "v": "$toMillis($now()) - max_file_age_days * 24 * 60 * 60 * 1000 ~> /* Udregner og returnerer datostempel max_file_age_days tilbage i tiden */\t$fromMillis() ~> /* Konverterer til data og tids format */\t$substring(0, 10) /* Konverterer til streng og fjern tidsstempel */\t",
+      "vt": "jsonata"
+    },
+    {
+      "t": "else"
+    }
+  ],
+  "checkall": "false",
+  "repair": false,
+  "outputs": 2,
+  "x": 410,
+  "y": 300,
+  "wires": [
+    [
+      "a713818e03fcf4ec",
+      "f998e08a71c1f45e"
+    ],
+    [
+      "e1e6ba7375f49afd"
+    ]
+  ],
+  "outputLabels": [
+    "created today",
+    ""
+  ],
+  "_order": 205
+}
+
+module.exports = Node;

--- a/node-red/flows_js/switch.b6f6580c94e57efa.flows.js
+++ b/node-red/flows_js/switch.b6f6580c94e57efa.flows.js
@@ -1,0 +1,35 @@
+const Node = {
+  "id": "b6f6580c94e57efa",
+  "type": "switch",
+  "z": "6b360b454d19172a",
+  "g": "12de71dcddfdf75d",
+  "name": "Check statusCode for sucess",
+  "property": "statusCode",
+  "propertyType": "msg",
+  "rules": [
+    {
+      "t": "eq",
+      "v": "200",
+      "vt": "num"
+    },
+    {
+      "t": "else"
+    }
+  ],
+  "checkall": "true",
+  "repair": false,
+  "outputs": 2,
+  "x": 640,
+  "y": 460,
+  "wires": [
+    [
+      "005e3b79e2cf7c32"
+    ],
+    [
+      "d724de646703fe6a"
+    ]
+  ],
+  "_order": 217
+}
+
+module.exports = Node;

--- a/node-red/flows_js/switch.d09e9abbc38df8c5.flows.js
+++ b/node-red/flows_js/switch.d09e9abbc38df8c5.flows.js
@@ -29,7 +29,7 @@ const Node = {
       "6fe4579af68bd2ea"
     ]
   ],
-  "_order": 116
+  "_order": 135
 }
 
 module.exports = Node;

--- a/node-red/flows_js/switch.eec02a801697c1a2.flows.js
+++ b/node-red/flows_js/switch.eec02a801697c1a2.flows.js
@@ -1,0 +1,35 @@
+const Node = {
+  "id": "eec02a801697c1a2",
+  "type": "switch",
+  "z": "6b360b454d19172a",
+  "g": "bb671390488c23f1",
+  "name": "Check statusCode for sucess",
+  "property": "statusCode",
+  "propertyType": "msg",
+  "rules": [
+    {
+      "t": "eq",
+      "v": "200",
+      "vt": "num"
+    },
+    {
+      "t": "else"
+    }
+  ],
+  "checkall": "true",
+  "repair": false,
+  "outputs": 2,
+  "x": 840,
+  "y": 120,
+  "wires": [
+    [
+      "dc172905d7889d81"
+    ],
+    [
+      "1edfd2ca9d9adb45"
+    ]
+  ],
+  "_order": 223
+}
+
+module.exports = Node;

--- a/node-red/flows_js/switch.fdd8f9690b8a671b.flows.js
+++ b/node-red/flows_js/switch.fdd8f9690b8a671b.flows.js
@@ -1,0 +1,34 @@
+const Node = {
+  "id": "fdd8f9690b8a671b",
+  "type": "switch",
+  "z": "80076417ef9f662a",
+  "name": "",
+  "property": "config.currentRetryAttempts",
+  "propertyType": "msg",
+  "rules": [
+    {
+      "t": "gte",
+      "v": "1",
+      "vt": "num"
+    },
+    {
+      "t": "else"
+    }
+  ],
+  "checkall": "true",
+  "repair": false,
+  "outputs": 2,
+  "x": 190,
+  "y": 100,
+  "wires": [
+    [
+      "b5376498af36d2bd"
+    ],
+    [
+      "b340dcdc1c773927"
+    ]
+  ],
+  "_order": 189
+}
+
+module.exports = Node;

--- a/node-red/flows_js/template.1582f6ecc6731fd7.flows.js
+++ b/node-red/flows_js/template.1582f6ecc6731fd7.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "43d0cf92514303e7"
     ]
   ],
-  "_order": 230
+  "_order": 291
 }
 
 Node.template = `

--- a/node-red/flows_js/template.2d9e69a26787f421.flows.js
+++ b/node-red/flows_js/template.2d9e69a26787f421.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "7f3fa659dc7e3a5c"
     ]
   ],
-  "_order": 193
+  "_order": 254
 }
 
 Node.template = `

--- a/node-red/flows_js/template.2e39b79d2576f9ba.flows.js
+++ b/node-red/flows_js/template.2e39b79d2576f9ba.flows.js
@@ -1,0 +1,34 @@
+const Node = {
+  "id": "2e39b79d2576f9ba",
+  "type": "template",
+  "z": "6b360b454d19172a",
+  "g": "ae64c3f2c1c354b3",
+  "name": "build metrics",
+  "field": "payload.metrics",
+  "fieldType": "msg",
+  "format": "handlebars",
+  "syntax": "mustache",
+  "template": "",
+  "output": "json",
+  "x": 1090,
+  "y": 280,
+  "wires": [
+    []
+  ],
+  "_order": 210
+}
+
+Node.template = `
+{
+    "op": "inc",
+    "val": 1,
+    "labels": {
+        "dataset": "{{dataset}}",
+        "responseUrl": "{{{responseUrl}}}",
+        "http-status": {{statusCode}},
+        "file-status" : "{{count}} datafiles eligible for pull, because file age is within {{max_file_age_days}} days"
+    }
+}
+`
+
+module.exports = Node;

--- a/node-red/flows_js/template.2e9339b2c18a23f4.flows.js
+++ b/node-red/flows_js/template.2e9339b2c18a23f4.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "aa4085ae631b7f7f"
     ]
   ],
-  "_order": 174
+  "_order": 235
 }
 
 Node.template = `

--- a/node-red/flows_js/template.3e67a5def24cc8e4.flows.js
+++ b/node-red/flows_js/template.3e67a5def24cc8e4.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "f4071b3393682d2e"
     ]
   ],
-  "_order": 181
+  "_order": 242
 }
 
 Node.template = `

--- a/node-red/flows_js/template.4d9691fedb0a0717.flows.js
+++ b/node-red/flows_js/template.4d9691fedb0a0717.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 146
+  "_order": 165
 }
 
 Node.template = `

--- a/node-red/flows_js/template.5b1c780ffe35c1eb.flows.js
+++ b/node-red/flows_js/template.5b1c780ffe35c1eb.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "4be122699e16f822"
     ]
   ],
-  "_order": 248
+  "_order": 309
 }
 
 Node.template = `

--- a/node-red/flows_js/template.6440c7c789cb52fe.flows.js
+++ b/node-red/flows_js/template.6440c7c789cb52fe.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "ea6b9ddd404c6bfa"
     ]
   ],
-  "_order": 220
+  "_order": 281
 }
 
 Node.template = `

--- a/node-red/flows_js/template.74d1dfee25742878.flows.js
+++ b/node-red/flows_js/template.74d1dfee25742878.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "921fba1309b4cc59"
     ]
   ],
-  "_order": 211
+  "_order": 272
 }
 
 Node.template = `

--- a/node-red/flows_js/template.75c15c71a7c0076e.flows.js
+++ b/node-red/flows_js/template.75c15c71a7c0076e.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 125
+  "_order": 144
 }
 
 Node.template = `

--- a/node-red/flows_js/template.85f69593f6d7665e.flows.js
+++ b/node-red/flows_js/template.85f69593f6d7665e.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "37c93df8cc9511ca"
     ]
   ],
-  "_order": 245
+  "_order": 306
 }
 
 Node.template = `

--- a/node-red/flows_js/template.9014ce0c1ddf1f70.flows.js
+++ b/node-red/flows_js/template.9014ce0c1ddf1f70.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 149
+  "_order": 168
 }
 
 Node.template = `

--- a/node-red/flows_js/template.bb89ca1a3f3c4750.flows.js
+++ b/node-red/flows_js/template.bb89ca1a3f3c4750.flows.js
@@ -1,0 +1,34 @@
+const Node = {
+  "id": "bb89ca1a3f3c4750",
+  "type": "template",
+  "z": "6b360b454d19172a",
+  "g": "ae64c3f2c1c354b3",
+  "name": "build metrics",
+  "field": "payload.metrics",
+  "fieldType": "msg",
+  "format": "handlebars",
+  "syntax": "mustache",
+  "template": "",
+  "output": "json",
+  "x": 1090,
+  "y": 320,
+  "wires": [
+    []
+  ],
+  "_order": 207
+}
+
+Node.template = `
+{
+    "op": "inc",
+    "val": 1,
+    "labels": {
+        "dataset": "{{dataset}}",
+        "responseUrl": "{{{responseUrl}}}",
+        "http-status": {{statusCode}},
+        "file-status" : "{{count}} datafiles excluded from pull, beacuse file age exceeds {{max_file_age_days}} days"
+    }
+}
+`
+
+module.exports = Node;

--- a/node-red/flows_js/template.c0a1ad499d5c94df.flows.js
+++ b/node-red/flows_js/template.c0a1ad499d5c94df.flows.js
@@ -1,0 +1,29 @@
+const Node = {
+  "id": "c0a1ad499d5c94df",
+  "type": "template",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "Opsæt kolonner",
+  "field": "columns",
+  "fieldType": "msg",
+  "format": "sql",
+  "syntax": "mustache",
+  "template": "",
+  "output": "str",
+  "x": 620,
+  "y": 400,
+  "wires": [
+    [
+      "38291a57af9afb3e"
+    ]
+  ],
+  "_order": 332
+}
+
+Node.template = `
+{{#payload.flatlist}}
+{{name}} {{type}},
+{{/payload.flatlist}}
+`
+
+module.exports = Node;

--- a/node-red/flows_js/template.cabaa0127db8b20a.flows.js
+++ b/node-red/flows_js/template.cabaa0127db8b20a.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "8899c8d86911d51f"
     ]
   ],
-  "_order": 236
+  "_order": 297
 }
 
 Node.template = `

--- a/node-red/flows_js/template.cc4372cb27df1b3d.flows.js
+++ b/node-red/flows_js/template.cc4372cb27df1b3d.flows.js
@@ -1,0 +1,31 @@
+const Node = {
+  "id": "cc4372cb27df1b3d",
+  "type": "template",
+  "z": "452aaf8dc5cd8d45",
+  "g": "80e6cc7cb0d92329",
+  "name": "Forespørgsel ↓\\n Opret tabel hvis der ikke \\n eksisterer en i forvejen ",
+  "field": "topic",
+  "fieldType": "msg",
+  "format": "sql",
+  "syntax": "mustache",
+  "template": "",
+  "output": "str",
+  "x": 490,
+  "y": 500,
+  "wires": [
+    [
+      "1adb98814879c48c"
+    ]
+  ],
+  "_order": 334
+}
+
+Node.template = `
+CREATE TABLE if not exists {{flow.tablename}} (
+created TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+last_updated TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+{{columns}}
+);
+`
+
+module.exports = Node;

--- a/node-red/flows_js/template.daa7a7e364322fd6.flows.js
+++ b/node-red/flows_js/template.daa7a7e364322fd6.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "077bfbcc6043bdb1"
     ]
   ],
-  "_order": 196
+  "_order": 257
 }
 
 Node.template = `

--- a/node-red/flows_js/template.f685a017c25bbbeb.flows.js
+++ b/node-red/flows_js/template.f685a017c25bbbeb.flows.js
@@ -15,7 +15,7 @@ const Node = {
   "wires": [
     []
   ],
-  "_order": 122
+  "_order": 141
 }
 
 Node.template = `

--- a/node-red/flows_js/timed_counter.3d76d476ede49cfa.flows.js
+++ b/node-red/flows_js/timed_counter.3d76d476ede49cfa.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "75c15c71a7c0076e"
     ]
   ],
-  "_order": 124
+  "_order": 143
 }
 
 module.exports = Node;

--- a/node-red/flows_js/timed_counter.58c3d6c42e0d8cdc.flows.js
+++ b/node-red/flows_js/timed_counter.58c3d6c42e0d8cdc.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "f685a017c25bbbeb"
     ]
   ],
-  "_order": 123
+  "_order": 142
 }
 
 module.exports = Node;

--- a/node-red/flows_js/timed_counter.7344e720e0250413.flows.js
+++ b/node-red/flows_js/timed_counter.7344e720e0250413.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "4d9691fedb0a0717"
     ]
   ],
-  "_order": 147
+  "_order": 166
 }
 
 module.exports = Node;

--- a/node-red/flows_js/timed_counter.a713818e03fcf4ec.flows.js
+++ b/node-red/flows_js/timed_counter.a713818e03fcf4ec.flows.js
@@ -1,0 +1,23 @@
+const Node = {
+  "id": "a713818e03fcf4ec",
+  "type": "timed-counter",
+  "z": "6b360b454d19172a",
+  "g": "ae64c3f2c1c354b3",
+  "name": "",
+  "timelimit": "1",
+  "timeunit": "1000",
+  "withhold": true,
+  "fixedtimeout": false,
+  "pertopic": false,
+  "countlimit": "",
+  "x": 900,
+  "y": 280,
+  "wires": [
+    [
+      "2e39b79d2576f9ba"
+    ]
+  ],
+  "_order": 209
+}
+
+module.exports = Node;

--- a/node-red/flows_js/timed_counter.b1b2d1d99797f590.flows.js
+++ b/node-red/flows_js/timed_counter.b1b2d1d99797f590.flows.js
@@ -17,7 +17,7 @@ const Node = {
       "9014ce0c1ddf1f70"
     ]
   ],
-  "_order": 148
+  "_order": 167
 }
 
 module.exports = Node;

--- a/node-red/flows_js/timed_counter.e1e6ba7375f49afd.flows.js
+++ b/node-red/flows_js/timed_counter.e1e6ba7375f49afd.flows.js
@@ -1,0 +1,23 @@
+const Node = {
+  "id": "e1e6ba7375f49afd",
+  "type": "timed-counter",
+  "z": "6b360b454d19172a",
+  "g": "ae64c3f2c1c354b3",
+  "name": "",
+  "timelimit": "1",
+  "timeunit": "1000",
+  "withhold": true,
+  "fixedtimeout": false,
+  "pertopic": false,
+  "countlimit": "",
+  "x": 900,
+  "y": 320,
+  "wires": [
+    [
+      "bb89ca1a3f3c4750"
+    ]
+  ],
+  "_order": 208
+}
+
+module.exports = Node;

--- a/node-red/flows_js/tls_config.5c13e4731fd7f4cf.flows.js
+++ b/node-red/flows_js/tls_config.5c13e4731fd7f4cf.flows.js
@@ -11,7 +11,7 @@ const Node = {
   "servername": "",
   "verifyservercert": true,
   "alpnprotocol": "",
-  "_order": 98
+  "_order": 117
 }
 
 module.exports = Node;


### PR DESCRIPTION
First version of dynamic datalake generator added.

It uses a custom suggestSqlDataType function that has basic support for suggesting and adding valid SQL datatypes to an data input object.

Currently only INTEGER, FLOAT, DATE, DATETIME, VARCHAR(255) is supported for automatic datatype adding.

Next version will include a generic SQL query generator, compatible with MariaDB at least.

